### PR TITLE
Replace ethereum-ens sample code with ensjs code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Top-level domains, like ‘.eth’ and ‘.test’ are owned by smart contracts 
 
 Because of the hierarchal nature of ENS, anyone who owns a domain at any level may configure subdomains - for themselves or others - as desired. For instance, if Alice owns 'alice.eth', she can create 'pay.alice.eth' and configure it as she wishes.
 
-ENS is deployed on the Ethereum main network and on several test networks. If you use a library such as the [ethereum-ens](https://www.npmjs.com/package/ethereum-ens) Javascript library, or an end-user application, it will automatically detect the network you are interacting with and use the ENS deployment on that network.
+ENS is deployed on the Ethereum main network and on several test networks. If you use a library such as the [ensjs](https://www.npmjs.com/package/@ensdomains/ensjs) Javascript library, or an end-user application, it will automatically detect the network you are interacting with and use the ENS deployment on that network.
 
 You can try ENS out for yourself now by using the [ENS manager](https://app.ens.domains/), or by using any of the many ENS enabled applications on [our homepage](https://ens.domains/).
 

--- a/dapp-developer-guide/ens-libraries.md
+++ b/dapp-developer-guide/ens-libraries.md
@@ -4,20 +4,23 @@ ENS support is available in many popular languages. If you know of a library tha
 
 ### Javascript
 
-* [ethereum-ens](https://www.npmjs.com/package/ethereum-ens), maintained by the ENS developers
-* [ethjs-ens](https://www.npmjs.com/package/ethjs-ens)
+* [ensjs](https://www.npmjs.com/package/@ensdomains/ensjs), maintained by the ENS developers
+* [ethereum-ens](https://www.npmjs.com/package/ethereum-ens) (deprecated)
+* [react-ens-address](https://github.com/ensdomains/react-ens-address)
 * [ethers.js](https://github.com/ethers-io/ethers.js)
 * [web3.js](https://web3js.readthedocs.io/en/1.0/web3-eth-ens.html)
+* [embark.io](https://framework.embarklabs.io/docs/naming_configuration.html)
+* [waffle.io](https://ethereum-waffle.readthedocs.io/en/latest/ens.html)
 
 #### Which Javascript library should I use?
 
-If you are already using web3.js, and do not require functionality such as creating subdomains, transferring ownership, or updating resolvers, use web3.js's ENS support.
+If you are already using web3.js or ethers.js, and do not require functionality such as creating subdomains, transferring ownership, or updating resolvers, use built in ENS features of these libraries.
 
-If you are already using ethjs, and only need to do forward and reverse resolution of ENS names, use ethjs's ENS support.
+If you are using React and only need to do forward and reverse resolution of ENS names with built in UI, use react-ens-address.
 
-If you are already using ethers.js, and only need to do forward and reverse resolution of ENNS names, use ethers.js's ENS support.
+If you want to have ENS instance deployed into your dev environment, you may want to use emabark.io or waffle.io which allows you to configure/deploy ENS registry in your Ethereum test instance.
 
-Otherwise, use ethereum-ens.
+Otherwise, use ensjs.
 
 #### Accessing smart contracts directly
 

--- a/dapp-developer-guide/managing-names.md
+++ b/dapp-developer-guide/managing-names.md
@@ -5,9 +5,9 @@
 Each name in ENS has an owner. This account or contract is the only one that may make changes to the name in the ENS registry. The owner of a name can transfer ownership to any other account.
 
 {% tabs %}
-{% tab title="ethereum-ens" %}
+{% tab title="ensjs" %}
 ```javascript
-await ens.setOwner('alice.eth', '0x1234...', {from: ...});
+await ens.name('alice.eth').setOwner('0x1234...');
 ```
 {% endtab %}
 
@@ -30,9 +30,9 @@ ns.setup_owner('alice.eth', '0x1234...')
 The owner of any domain can configure subdomains as desired. This is achieved by creating a subdomain and setting its owner to the desired address - this can be the same as the owner of the parent domain, or any other address.
 
 {% tabs %}
-{% tab title="ethereum-ens" %}
+{% tab title="ensjs" %}
 ```text
-await ens.setSubnodeOwner('iam.alice.eth', '0x1234...', {from: ...});
+await ens.name('alice.eth').createSubdomain('iam');
 ```
 {% endtab %}
 
@@ -65,9 +65,9 @@ Before a newly created domain or subdomain can be used, a resolver address must 
 Most commonly, names are set to use a 'standard' resolver called the public resolver, which provides commonly-used functionality, but anyone may write and deploy their own special-purpose resolver; see the resolver interface definition for details.
 
 {% tabs %}
-{% tab title="ethereum-ens" %}
+{% tab title="ensjs" %}
 ```text
-await ens.setResolver('iam.alice.eth', '0x1234...', {from: ...});
+await ens.name('iam.alice.eth').setResolver('0x1234');
 ```
 
 On mainnet and the Kovan test network, 'resolver.eth' is configured to point to the latest deployed version of the public resolver, making it possible to easily configure a name to use the public resolver:
@@ -101,9 +101,9 @@ Each resolver may specify its own mechanism for updating records, but a standard
 ### Updating the Address Record
 
 {% tabs %}
-{% tab title="ethereum-ens" %}
+{% tab title="ensjs" %}
 ```javascript
-await ens.resolver('iam.alice.eth').setAddr('0x1234...', {from: ...});
+await ens.name('iam.alice.eth').setAddr('ETH', '0x1234...');
 ```
 {% endtab %}
 
@@ -130,12 +130,12 @@ ns.setup_address('iam.alice.eth', '0x1234...')
 
 ### Updating Other Records
 
-Some libraries - presently only ethereum-ens, go-ens and web3.js - support updating other record types, such as content hashes and text records, using the same pattern. For example, to set or update a text record:
+Some libraries - presently only ensjs, go-ens and web3.js - support updating other record types, such as content hashes and text records, using the same pattern. For example, to set or update a text record:
 
 {% tabs %}
-{% tab title="ethereum-ens" %}
+{% tab title="ensjs" %}
 ```javascript
-ens.resolver('iam.alice.eth').setText('test', 'Test record', {from: ...});
+ens.name('iam.alice.eth').setText('test', 'Test record');
 ```
 {% endtab %}
 

--- a/dapp-developer-guide/resolving-names.md
+++ b/dapp-developer-guide/resolving-names.md
@@ -5,9 +5,9 @@
 The simplest and most frequently used function in ENS is resolving a name. Names can have many types of data associated with them; the most common is an Ethereum address. Resolving a name to an Ethereum address using a library is simple:
 
 {% tabs %}
-{% tab title="ethereum-ens" %}
+{% tab title="ensjs" %}
 ```javascript
-var address = await ens.resolver('alice.eth').addr();
+var address = await ens.name('resolver.eth').getAddress();
 ```
 {% endtab %}
 
@@ -102,12 +102,12 @@ ENS does not enforce the accuracy of reverse records - for instance, anyone may 
 Most libraries provide functionality for doing reverse resolution:
 
 {% tabs %}
-{% tab title="ethereum-ens" %}
+{% tab title="ensjs" %}
 ```javascript
 const address = '0x1234...';
-var name = await ens.reverse(address).name()
+var name = await ens.getName(address)
 // Check to be sure the reverse record is correct.
-if(address != await ens.resolver(name).addr()) {
+if(address != await ens.name(name).getAddress()) {
   name = null;
 }
 ```

--- a/dapp-developer-guide/working-with-ens.md
+++ b/dapp-developer-guide/working-with-ens.md
@@ -2,15 +2,14 @@
 
 Before you can begin interacting with ENS, you will need to obtain a reference to the ENS registry. How you do this depends on the library you are using.
 
-Example code for the Javascript-based APIs \(ethereum-ens, web3.js, ethjs-ens, and ethers.js\) here expect that they are being run inside a DApp browser, such as Chrome with [metamask installed](https://metamask.github.io/metamask-docs/Main_Concepts/Getting_Started), which exposes the `ethereum` object.
+Example code for the Javascript-based APIs \(ensjs, web3.js, ethjs-ens, and ethers.js\) here expect that they are being run inside a DApp browser, such as Chrome with [metamask installed](https://metamask.github.io/metamask-docs/Main_Concepts/Getting_Started), which exposes the `ethereum` object.
 
 {% tabs %}
-{% tab title="ethereum-ens" %}
+{% tab title="ensjs" %}
 ```javascript
-var ENS = require('ethereum-ens');
+import ENS, { getEnsAddress } from '@ensdomains/ensjs'
 
-var accounts = ethereum.enable();
-var ens = new ENS(ethereum);
+const ens = new ENS({ provider, ensAddress: getEnsAddress('1') })
 ```
 {% endtab %}
 


### PR DESCRIPTION

- Mark `ethereum-ens` as deprecate
- Add `ensjs` as main js lib
- Mention `embark`, `waffle`, and `react-ens-address`
- Replace `ethereum-ens` example with `ensjs` example