### PR TITLE
normalize in eth-ens-namehash doesn't use Unicode

### DIFF
--- a/contract-api-reference/name-processing.md
+++ b/contract-api-reference/name-processing.md
@@ -14,7 +14,7 @@ Before a name can be converted to a node hash using Namehash, the name must firs
 
 Applications using ENS and processing human-readable names must follow [UTS46](http://unicode.org/reports/tr46/) for normalization and validation. Processing should be done with non-transitional rules, and with UseSTD3ASCIIRules=true.
 
-The [eth-ens-namehash](https://www.npmjs.com/package/eth-ens-namehash) Javascript library performs both normalization and hashing as described here. All of the [ENS libraries](../dapp-developer-guide/ens-libraries.md) covered in the DApp Developer Guide also perform normalization and hashing.
+The [eth-ens-namehash](https://www.npmjs.com/package/@ensdomains/eth-ens-namehash) Javascript library performs both normalization and hashing as described here. All of the [ENS libraries](../dapp-developer-guide/ens-libraries.md) covered in the DApp Developer Guide also perform normalization and hashing.
 
 ## Hashing Names
 


### PR DESCRIPTION
The forked eth-ens-namehash library at https://www.npmjs.com/package/@ensdomains/eth-ens-namehash does correctly normalize the name using uts46.toUnicode(name, {useStd3ASCII: true, transitional: false}).