### PR TITLE
Remove "`" from import statement for contracts

### DIFF
--- a/dapp-developer-guide/ens-libraries.md
+++ b/dapp-developer-guide/ens-libraries.md
@@ -32,7 +32,7 @@ This is how you include abi into your frontend code.
 import {
   ENS,
   PublicResolver
-} from '@ensdomains/ens-contracts'`
+} from '@ensdomains/ens-contracts'
 ```
 
 This is how you import our smartcontract within Solidity.


### PR DESCRIPTION
Noticed this when I tried using the copy feature in the GitBook-rendered docs