### PR TITLE
deleted deprecated testnets, added Alchemy Goerli

### DIFF
--- a/ens-deployments.md
+++ b/ens-deployments.md
@@ -2,7 +2,7 @@
 
 If you are working with an [ENS library](dapp-developer-guide/ens-libraries.md), your library will automatically find the ENS deployment you need. If for whatever reason, you need to interact with ENS directly, details for the currently supported deployments are detailed here.
 
-The ENS registry is deployed at 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e. This same address is used across Mainnet, Ropsten, Rinkeby and Goerli.
+The ENS registry is deployed at 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e. This same address is used across Mainnet and Goerli.
 
 On mainnet, the following registrars are deployed:
 
@@ -25,7 +25,5 @@ For other contract addresses such as root, multisig, controller, public resolver
 Back in February 2020, the ENS registry was migrated to the new contract address to patch security vulnerabilities \(Read more detail [here](ens-migration-february-2020/technical-description.md)\). The prior registry addresses were:
 
 * Mainnet, at [0x314159265dd8dbb310642f98f50c066173c1259b](https://etherscan.io/address/0x314159265dd8dbb310642f98f50c066173c1259b#code).
-* Ropsten, at [0x112234455c3a32fd11230c42e7bccd4a84e02010](https://ropsten.etherscan.io/address/0x112234455c3a32fd11230c42e7bccd4a84e02010).
-* Rinkeby, at [0xe7410170f87102df0055eb195163a03b7f2bff4a](https://rinkeby.etherscan.io/address/0xe7410170f87102df0055eb195163a03b7f2bff4a).
 * Goerli, at [0x112234455c3a32fd11230c42e7bccd4a84e02010](https://goerli.etherscan.io/address/0x112234455c3a32fd11230c42e7bccd4a84e02010).
 


### PR DESCRIPTION
Hey Makoto!

I am John, and I’m an ambassador for Alchemy. Commend how ENS is providing decentralized domains in Web3

Noticed you referenced Rinkeby and Ropsten in your documentation, which are now deprecated due to the Ethereum Merge, in your documentation. As you probably know, Goerli is now the main testnet.

If helpful, I’m linking Alchemy’s goerli faucet (anyone can get 0.5 Goerli testnet ETH free per day) here - https://goerlifaucet.com/. Also in case it’s useful to your readers, here’s some good dev docs - https://www.alchemy.com/overviews/migrate-from-rinkeby-to-goerli https://www.alchemy.com/overviews/migrate-from-ropsten-to-goerli

Let us know if Alchemy can ever be helpful, and keep up the awesome content!

=
John.