### PR TITLE
Update ``web3.py`` examples across documentation

### DIFF
--- a/app/local/config/languages.ts
+++ b/app/local/config/languages.ts
@@ -93,7 +93,7 @@ export const LanguagePresets = configureLanguages({
     },
     web3py: {
         icon: '',
-        name: 'Web3.py',
+        name: 'web3.py',
         language: 'python',
         fallback: [],
     },

--- a/app/src/components/Libraries.tsx
+++ b/app/src/components/Libraries.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
 import { FaJava, FaReact, FaRust } from 'react-icons/fa';
-import { SiDelphi, SiKotlin, SiNuget } from 'react-icons/si';
+import { SiDelphi, SiKotlin, SiNuget, SiPython } from 'react-icons/si';
 import { TbBrandGolang, TbBrandJavascript } from 'react-icons/tb';
 
 type Language = {
@@ -76,6 +76,18 @@ export const ensLibraries: Language[] = [
                 href: 'https://github.com/alloy-rs/',
                 name: 'Alloy',
                 description: '',
+                logo: undefined,
+            },
+        ],
+    },
+    {
+        name: 'Python',
+        logo: <SiPython />,
+        libraries: [
+            {
+                href: 'https://github.com/ethereum/web3.py',
+                name: 'web3.py',
+                description: 'A python interface for interacting with the Ethereum blockchain and ecosystem.',
                 logo: undefined,
             },
         ],

--- a/docs/dao/proposals/3.7.mdx
+++ b/docs/dao/proposals/3.7.mdx
@@ -52,6 +52,7 @@ This is a vote to approve [ENSIP-15: Normalization Standard.](https://docs.ens.d
     1. Javascript — [adraffy/ens-normalize](https://github.com/adraffy/ens-normalize.js)
     2. Javascript — [ensdomains/eth-ens-namehash](https://github.com/ensdomains/eth-ens-namehash)
     3. Python — [namehash/ens-normalize-python](https://github.com/namehash/ens-normalize-python)
+    4. Python - [ethereum/web3.py](https://github.com/ethereum/web3.py)
   * Web Frameworks using ENSIP-15:
     1. Javascript — [ethers/ethers.io](https://github.com/ethers-io/ethers.js/)
     2. Javascript — [web3/web3.js](https://github.com/web3/web3.js)

--- a/docs/dao/proposals/3.7.mdx
+++ b/docs/dao/proposals/3.7.mdx
@@ -52,7 +52,6 @@ This is a vote to approve [ENSIP-15: Normalization Standard.](https://docs.ens.d
     1. Javascript — [adraffy/ens-normalize](https://github.com/adraffy/ens-normalize.js)
     2. Javascript — [ensdomains/eth-ens-namehash](https://github.com/ensdomains/eth-ens-namehash)
     3. Python — [namehash/ens-normalize-python](https://github.com/namehash/ens-normalize-python)
-    4. Python - [ethereum/web3.py](https://github.com/ethereum/web3.py)
   * Web Frameworks using ENSIP-15:
     1. Javascript — [ethers/ethers.io](https://github.com/ethers-io/ethers.js/)
     2. Javascript — [web3/web3.js](https://github.com/web3/web3.js)

--- a/docs/resolution/index.mdx
+++ b/docs/resolution/index.mdx
@@ -58,6 +58,12 @@ const ensResolver = await publicClient.getEnsResolver({
 });
 ```
 
+```py {{ variant: 'web3py', link: 'https://web3py.readthedocs.io/en/latest/ens_overview.html#working-with-resolvers' }}
+from ens.auto import ns
+
+resolver = ns.resolver('alice.eth')
+```
+
 </CodeGroup>
 
 To verify which specifications are implemented by a resolver you can call the `supportsInterface(bytes4 interfaceID)` on the resolver with the interfaceID you would like to test for.

--- a/docs/web/avatars.mdx
+++ b/docs/web/avatars.mdx
@@ -64,6 +64,12 @@ const ensAvatar = await publicClient.getEnsAvatar({
 });
 ```
 
+```py {{ variant: 'web3py', link: 'https://web3py.readthedocs.io/en/latest/ens_overview.html#read-text-metadata-for-an-ens-record' }}
+from ens.auto import ns
+
+avatar = ns.get_text('alice.eth', 'avatar')
+```
+
 ```go {{ title: "Go", variant: "go" }}
 package main
 

--- a/docs/web/records.mdx
+++ b/docs/web/records.mdx
@@ -114,6 +114,17 @@ const ensText = await publicClient.getEnsText({
 });
 ```
 
+```python {{ title: "web3.py", variant: "web3.py", link: "https://web3py.readthedocs.io/en/latest/ens_overview.html#text-records" }}
+from ens.auto import ns
+
+# set text
+ns.set_text('alice.eth', 'url', 'https://example.com')
+
+# get text
+url = ns.get_text('alice.eth', 'url')
+assert url == 'https://example.com'
+```
+
 ```tsx {{ title: "Ethers.rs", variant: "rust" }}
 // TODO: Not Implemented
 ```

--- a/docs/web/resolution.mdx
+++ b/docs/web/resolution.mdx
@@ -55,6 +55,12 @@ const ensAddress = await publicClient.getEnsAddress({
 });
 ```
 
+```py {{ title: 'web3.py (Python)', variant: 'web3py', link: 'https://web3py.readthedocs.io/en/latest/ens_overview.html#get-the-address-for-an-ens-name' }}
+from ens.auto import ns
+
+address = ns.address('alice.eth')
+```
+
 ```rust {{ variant: 'ethers-rs' }}
 let provider = Provider::<Http>::try_from("https://mainnet.infura.io/v3/...")?;
 
@@ -123,9 +129,6 @@ const records = client.getRecords({
 });
 ```
 
-```python {{ variant: 'web3py' }}
-address = ns.address('alice.eth')
-```
 
 ```csharp {{ variant: "nethereum" }}
 var ensService = new Nethereum.ENS.ENSService(web3);
@@ -170,6 +173,12 @@ const ensName = await publicClient.getEnsAddress({
 ```ts {{ title: 'Ethers.js (TS)', variant: 'ethers-v5', link: 'https://docs.ethers.org/v5/api/providers/provider/#EnsResolver' }}
 const resolver = await provider.getResolver("luc.eth");
 const btcAddress = await resolver?.getAddress(0);
+```
+
+```py {{ title: 'web3.py (Python)', variant: 'web3py', link: 'https://web3py.readthedocs.io/en/latest/ens_overview.html#multichain-address-resolution' }}
+from ens.auto import ns
+
+eth_address = ns.address('alice.eth', coin_type=60)
 ```
 
 </CodeGroup>

--- a/docs/web/reverse.mdx
+++ b/docs/web/reverse.mdx
@@ -58,6 +58,14 @@ const ensName = await publicClient.getEnsName({
 });
 ```
 
+```py {{ variant: 'web3py', link: 'https://web3py.readthedocs.io/en/latest/ens_overview.html#get-the-ens-name-for-an-address' }}
+from ens.auto import ns
+
+# 0x225f137127d9067788314bc7fcc1f36746a3c3B5 -> luc.eth
+name = ns.name('0x225f137127d9067788314bc7fcc1f36746a3c3B5')
+```
+
+
 ```go {{ variant: 'go', title: 'Go' }}
 package main
 
@@ -134,6 +142,12 @@ const hash = await setPrimaryName(wallet, {
     name: 'ens.eth',
 });
 // 0x...
+```
+
+```py {{ variant: 'web3py', link: 'https://web3py.readthedocs.io/en/latest/ens_overview.html#link-an-address-to-a-name' }}
+from ens.auto import ns
+
+ns.setup_name('myname.eth', my_address)
 ```
 
 </CodeGroup>


### PR DESCRIPTION
I noticed some examples for *web3.py* were not up-to-date. I tried to check against all examples and did my best to update them as per *web3.py* >= `v6.0.0`.