### PR TITLE
fix broken refs to docs-v2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,11 @@ This guide will walk you through the process of contributing to the ENS docs. If
 
 #### Create a new issue
 
-If you spot a problem with the docs, [search if an issue already exists](https://github.com/ensdomains/docs-v2/issues). If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/ensdomains/docs-v2/issues/new).
+If you spot a problem with the docs, [search if an issue already exists](https://github.com/ensdomains/docs/issues). If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/ensdomains/docs/issues/new).
 
 #### Solve an issue
 
-Scan through our [existing issues](https://github.com/ensdomains/docs-v2/issues) to find one that interests you. You can narrow down the search using `labels` as filters. As a general rule, we don't assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
+Scan through our [existing issues](https://github.com/ensdomains/docs/issues) to find one that interests you. You can narrow down the search using `labels` as filters. As a general rule, we don't assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
 
 ### Make Changes
 

--- a/app/src/content/prose/repository/github/type.ts
+++ b/app/src/content/prose/repository/github/type.ts
@@ -3,8 +3,8 @@ type URLType = string;
 export type GithubRepositoryData = {
     id: string;
     node_id: string;
-    name: 'docs-v2';
-    full_name: 'ensdomains/docs-v2';
+    name: 'docs';
+    full_name: 'ensdomains/docs';
     private: false;
     // Big
     owner: object;

--- a/app/src/layout/details/variations/GitCommitLink.tsx
+++ b/app/src/layout/details/variations/GitCommitLink.tsx
@@ -8,7 +8,7 @@ import { FC, PropsWithChildren } from 'react';
 import { cx } from '@/lib/cx';
 
 const prefix = 'docs';
-const repo = 'ensdomains/docs-v2';
+const repo = 'ensdomains/docs';
 
 export const GitCommitLink: FC<
     PropsWithChildren<{ file: string; hash: string }>

--- a/app/src/layout/footer/contribute/ContributeLink.tsx
+++ b/app/src/layout/footer/contribute/ContributeLink.tsx
@@ -4,7 +4,7 @@ import { usePathname } from 'next/navigation';
 import { FC } from 'react';
 import { FiGithub } from 'react-icons/fi';
 
-const ROOT_REPO = 'ensdomains/docs-v2';
+const ROOT_REPO = 'ensdomains/docs';
 
 export const ContributeLink: FC<{ url?: string }> = ({ url }) => {
     if (!url) {

--- a/app/src/layout/header/Header.tsx
+++ b/app/src/layout/header/Header.tsx
@@ -98,7 +98,7 @@ export const Header = forwardRef<HTMLDivElement, { className?: string }>(
                         <div className="flex gap-4">
                             <MobileSearch />
                             <Link
-                                href="https://github.com/ensdomains/docs-v2"
+                                href="https://github.com/ensdomains/docs"
                                 target="_blank"
                                 aria-label="GitHub Repository"
                             >


### PR DESCRIPTION
Issue:
Corrected broken references in documentation from 'docs-v2' to 'docs'.

Changes Made:
Replaced instances of docs-v2 with the correct docs throughout the documentation.

Why is this necessary?
Ensures accurate and clear documentation for users.

How I Tested This:
Thorough manual review and local documentation build to confirm changes.

Checklist:
 Replaced all docs-v2 references with docs.
 Documentation builds successfully without errors.