### PR TITLE
Update index.mdx

### DIFF
--- a/docs/web/index.mdx
+++ b/docs/web/index.mdx
@@ -29,7 +29,7 @@ To learn more check out the [tools & libraries section](/web/libraries).
 <EmbedLink
     href="/web/libraries"
     title="Tools & Libraries"
-    description="To lorem ipsum dolor sit amet."
+    description="To learn about the available tools and libraries that interact with ENS"
 />
 
 {/* ## Examples
@@ -48,15 +48,15 @@ If you're interested in interacting with the resolver contract directly, you mig
 <EmbedLink
     href="/web/resolution"
     title="Address Resolution"
-    description="To lorem ipsum dolor sit amet."
+    description="To find guides on the address lookup features of ENS."
 />
 
 ## Subnames
 
 <EmbedLink
-    href="/web/subnames"
+    href="/web/subdomains"
     title="Issuing Subnames"
-    description="To lorem ipsum dolor sit amet."
+    description="To an overview of subdomains and the NameWrapper smart contract"
 />
 
 ## Registration
@@ -64,5 +64,5 @@ If you're interested in interacting with the resolver contract directly, you mig
 <EmbedLink
     href="/registry/eth"
     title="ETH Registrar"
-    description="To lorem ipsum dolor sit amet."
+    description="To an overview of the two smart contracts that make up the ETH Registrar."
 />


### PR DESCRIPTION
Removed the lorem ipsum of the link descriptions and fixed the link to the subdomains/subnames page.