### PR TITLE
Fix Edit on Github link.

### DIFF
--- a/app/src/layout/footer/contribute/ContributeLink.tsx
+++ b/app/src/layout/footer/contribute/ContributeLink.tsx
@@ -19,10 +19,13 @@ export const ContributeLink: FC<{ url?: string }> = ({ url }) => {
         return <></>;
     }
 
+    // Get current git branch
+    const branch = process.env.CF_PAGES_BRANCH || 'master';
+
     return (
         <a
-            href={`https://github.com/${ROOT_REPO}/edit/master${url}`}
-            className="flex items-center gap-2 text-xs text-ens-light-blue-primary dark:text-ens-dark-blue-primary"
+            href={`https://github.com/${ROOT_REPO}/edit/${branch}${url}`}
+            className="text-ens-light-blue-primary dark:text-ens-dark-blue-primary flex items-center gap-2 text-xs"
             target="_blank"
             rel="nofollow"
         >

--- a/app/src/layout/footer/contribute/ContributeLink.tsx
+++ b/app/src/layout/footer/contribute/ContributeLink.tsx
@@ -21,7 +21,7 @@ export const ContributeLink: FC<{ url?: string }> = ({ url }) => {
 
     return (
         <a
-            href={`https://github.com/${ROOT_REPO}/edit/main${url}`}
+            href={`https://github.com/${ROOT_REPO}/edit/master${url}`}
             className="flex items-center gap-2 text-xs text-ens-light-blue-primary dark:text-ens-dark-blue-primary"
             target="_blank"
             rel="nofollow"

--- a/app/src/layout/footer/contribute/ContributeLink.tsx
+++ b/app/src/layout/footer/contribute/ContributeLink.tsx
@@ -19,8 +19,7 @@ export const ContributeLink: FC<{ url?: string }> = ({ url }) => {
         return <></>;
     }
 
-    // Get current git branch
-    const branch = process.env.CF_PAGES_BRANCH || 'master';
+    const branch = 'master';
 
     return (
         <a


### PR DESCRIPTION
Link assumed branch "main" from docs-v2 but ensdomains/docs uses main. I fixed this in this PR.