### PR TITLE
Fix typo in TLD List page

### DIFF
--- a/docs/dns/tlds.mdx
+++ b/docs/dns/tlds.mdx
@@ -10,6 +10,6 @@ export const meta = {
 
 # Supported TLD List
 
-Allongside the `.eth` Top Level Domain, the ENS Protocol also supports most of your favourite DNS Top Level Domains (such as `.com`, `.cash` or `.domains`). The list below aims to show all TLDs and their current status.
+Alongside the `.eth` Top Level Domain, the ENS Protocol also supports most of your favourite DNS Top Level Domains (such as `.com`, `.cash` or `.domains`). The list below aims to show all TLDs and their current status.
 
 <TLDList />

--- a/docs/dns/tlds.mdx
+++ b/docs/dns/tlds.mdx
@@ -5,7 +5,7 @@ export const meta = {
     title: 'Supported TLD List',
     description: 'List of all supported DNS TLDs. Any DNS TLD that supports DNSSEC can be used with ENS.',
     emoji: '📝',
-    contributors: ['lucemans']
+    contributors: ['lucemans', '0xPenryn']
 };
 
 # Supported TLD List


### PR DESCRIPTION
"Allongside" -> "Alongside"