### PR TITLE
fix: updating Fleek's correct site mention

### DIFF
--- a/docs/dweb/intro.mdx
+++ b/docs/dweb/intro.mdx
@@ -48,7 +48,7 @@ or require to be actively stored on atleast one machine, also known as "pinning"
 ### Deploy your site {{ id: 'deploy' }}
 
 Several helpful tools and platforms exist that you can use to deploy your website to IPFS, Swarm, or Arweave.
-Most notably [fleek](https://fleek.co), [Pinata](https://pinata.cloud), and [Blumen](https://blumen.stauro.dev/).
+Most notably [fleek](https://fleek.xyz), [Pinata](https://pinata.cloud), and [Blumen](https://blumen.stauro.dev/).
 Helping you easily deploy your website to a decentralized storage network.
 
 ## Setting your ContentHash {{ id: 'set' }}


### PR DESCRIPTION
### Abstract
This PR aims to edit the deprecated fleek.co site mentions to the latest fleek.xyz site

### Importance of the PR
Fleek.co has been the go to site for a lot of decentralized deployments in the past but the platform has undergone a complete overhaul and is rebuilt from the ground up on fleek.xyz. fleek.co will be deprecated soon.

### Code Edit in the PR
its just a simple link change