### PR TITLE
Update CCIP-Read POST example url: omit `{sender}` and `.json`

### DIFF
--- a/docs/resolvers/ccip-read.mdx
+++ b/docs/resolvers/ccip-read.mdx
@@ -92,14 +92,15 @@ The URL for this gateway is determined by the `OffchainLookup` error, and is pas
 
 ### Implement Gateway Endpoint {{ navtitle: 'Implement Gateway', id: 'endpoint' }}
 
-There are two methods (GET and POST) you can choose to implement when writing a gateway. When your smart-contract reverts with the `OffchainLookup` error you can decide the url it returns.
-If `{data}` can be successfully substituted out of the URL a GET request will be made, if no `{data}` is present a POST request will be made instead, with the data instead submitted as the post body.
+There are two methods (GET and POST) you can choose to implement when writing a gateway. When your smart-contract reverts with the `OffchainLookup` error, you can decide the url it returns.
+If `{data}` can be successfully substituted out of the URL, a GET request will be made. If no `{data}` is present, a POST request will be made with the data submitted as the post body.
 
 <CodeGroup title="Request" presets="method">
 
 ```yaml {{ title: 'POST', variant: 'post' }}
 // POST if URL does not include '{data}' parameter
-URL: https://example.com/gateway/{sender}.json
+// Note: '{sender}' is not required but may be present
+URL: https://example.com/gateway/{sender}
 Method: POST
 Body: data
 ```


### PR DESCRIPTION
For clarity, the POST url doesn't seem to necessitate a `{sender}` and it also doesn't seem to make sense to POST to a `.json`. When we implemented CCIP-Read in web3.py, there was a bit of ambiguity on whether we should still include a check for `{sender}` in the url based on this example ([PR for this change](https://github.com/ethereum/web3.py/pull/3291)). I think this change would help clarify this for readers / implementers.