### PR TITLE
Typo corrections

### DIFF
--- a/docs/dweb/intro.mdx
+++ b/docs/dweb/intro.mdx
@@ -43,7 +43,7 @@ When it comes to hosting your files there are many options to choose from.
 
 Popular options include [IPFS](https://ipfs.io), [Swarm](https://ethswarm.org), and [Arweave](https://arweave.org).
 Depending on what option you go with your files are either permanently stored on a network,
-or require to be actively stored on atleast one machine, also known as "pinning".
+or require to be actively stored on at least one machine, also known as "pinning".
 
 ### Deploy your site {{ id: 'deploy' }}
 

--- a/docs/learn/dns.mdx
+++ b/docs/learn/dns.mdx
@@ -13,7 +13,7 @@ export const meta = {
     {/*TODO: User-friendly explanation of the fact that DNS names also work in the ENS system.*/}
 </>
 
-The Ethereum Name Service is so much more then just `.eth` names. It is a general-purpose naming system that can be used for any kind of name. This includes DNS names.
+The Ethereum Name Service is so much more than just `.eth` names. It is a general-purpose naming system that can be used for any kind of name. This includes DNS names.
 DNS functionality was originally introduced in [ENSIP-6](/ensip/6).
 
 ## Importing a DNS name

--- a/docs/terminology.mdx
+++ b/docs/terminology.mdx
@@ -124,7 +124,7 @@ This term is typically used with respect to the Ethereum Mainnet blockchain. If 
 
 ### CCIP Read
 
-The "Cross Chain Interoperability Procol Read" specification, also known as [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668), authored by Nick Johnson, is a specification that allows for secure and trustless offchain data retrieval.
+The "Cross Chain Interoperability Protocol Read" specification, also known as [EIP-3668](https://eips.ethereum.org/EIPS/eip-3668), authored by Nick Johnson, is a specification that allows for secure and trustless offchain data retrieval.
 
 It allows for an Ethereum call to defer to an [offchain gateway](/resolvers/ccip-read#writing-a-gateway) and then securely verify the resulting data on-chain.
 With respect to ENS, this is typically used for offchain subnames that don't exist in the core Registry.

--- a/docs/web/avatars.mdx
+++ b/docs/web/avatars.mdx
@@ -109,7 +109,7 @@ with some rules about what URI schemes are supported and how to process them. Fo
 Clients are expected to support a number of URI schemas, which aren't always web URIs, so the final result you see in your application
 will vary depending on how the library you are using has decided to handle avatar records.
 
-- `http(s):` - URI Scheme for for HTTP(S) URLs. Libraries will most likely return the result directly.
+- `http(s):` - URI Scheme for HTTP(S) URLs. Libraries will most likely return the result directly.
 - `ipfs:` - URI scheme for [IPFS hashes](). Libraries may decide to fetch the result from a public gateway for you.
 - `data:` - URI Scheme for [data URIs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
   Libraries will most likely return the result directly.


### PR DESCRIPTION
### Typo corrections

* dweb/intro.mdx:

"atleast" → should be written as "at least" (two separate words, not one).

Corrected.

* learn/dns.mdx

"so much more then" → should be "so much more than"
Explanation: The correct expression is "more than," not "more then."

Corrected.

* web/avatars.mdx

"for for" — There is a repeated word. Corrected.

* docs/terminology.mdx

"Cross Chain Interoperability Procol Read" — There is a typo in the term "Procol." It should be "Protocol". The corrected phrase is "Cross Chain Interoperability Protocol Read".

Corrected.