### PR TITLE
Fix spelling mistakes and typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ In this guide you will get an overview of the contribution workflow from opening
 
 ## Getting started
 
-This guide will walk you through the process of contributing to the ENS docs. If you are new to GitHub, you can checkout this [GitHub tutorial](https://guides.github.com/activities/hello-world/) to get started.
+This guide will walk you through the process of contributing to the ENS docs. If you are new to GitHub, you can check out this [GitHub tutorial](https://guides.github.com/activities/hello-world/) to get started.
 
 ### Issues
 
@@ -38,14 +38,14 @@ Commit the changes once you are happy with them. Upon creating a Pull Request yo
 
 ### Pull Request
 
-When you're finished with the changes, create a pull request, also known as a PR.
+When you're finished with the changes, create a Pull Request, also known as a PR.
 - Fill the "Ready for review" template so that we can review your PR. This template helps reviewers understand your changes as well as the purpose of your pull request.
 - Don't forget to [link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) if you are solving one.
 - Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
 Once you submit your PR, a Docs team member will review your proposal. We may ask questions or request additional information.
 - We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments. You can apply suggested changes directly through the UI. You can make any other changes in your fork, then commit them to your branch.
 - As you update your PR and apply changes, mark each conversation as [resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
-- If you run into any merge issues, checkout this [git tutorial](https://github.com/skills/resolve-merge-conflicts) to help you resolve merge conflicts and other issues.
+- If you run into any merge issues, check out this [git tutorial](https://github.com/skills/resolve-merge-conflicts) to help you resolve merge conflicts and other issues.
 
 ### Your PR is merged!
 

--- a/docs/ensip/11.mdx
+++ b/docs/ensip/11.mdx
@@ -1,6 +1,6 @@
 {/** @type {import('@/lib/mdxPageProps').MdxMetaProps} */}
 export const meta = {
-    description: 'Introduces coinType for EVM compatible chains (amending ENSIP9).',
+    description: 'Introduces coinType for EVM-compatible chains (amending ENSIP9).',
     contributors: [
         // Makoto Inoue
         'makoto'
@@ -11,19 +11,19 @@ export const meta = {
     }
 };
 
-# ENSIP-11: EVM compatible Chain Address Resolution
+# ENSIP-11: EVM-compatible Chain Address Resolution
 
-Introduces coinType for EVM compatible chains (amending [ENSIP-9](./9)).
+Introduces coinType for EVM-compatible chains (amending [ENSIP-9](./9)).
 
 ## Abstract
 
-This ENSIP extends [ENSIP 9 (multichain address resolution)](./9), dedicates a range of coin types for EVM compatible chains, and specifies a way to derive EVM chain IDs to the designated coin types.
+This ENSIP extends [ENSIP 9 (multichain address resolution)](./9), dedicates a range of coin types for EVM-compatible chains, and specifies a way to derive EVM chain IDs to the designated coin types.
 
-The dedicated range uses over 0x80000000 (2147483648) which is reserved under ENSIP 9 so there will be no possibility of coin type collision with other non EVM coin types to be added in future. However, some of coin types previously allocated to EVM chain ids will be deprecated.
+The dedicated range uses over 0x80000000 (2147483648) which is reserved under ENSIP 9 so there will be no possibility of coin type collision with other non-EVM coin types to be added in future. However, some of coin types previously allocated to EVM chain ids will be deprecated.
 
 ## Motivation
 
-The existing ENSIP 9 relies on the existence of coin types on [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) which was designed to define address encoding type for deterministic wallets. As the majority of EVM compatible chains inherit the same encoding type as Ethereum, it is redundant to keep requesting the addition of EVM compatible chains into SLIP 44. This specification standardises a way to derive coinType based on [Chain ID](https://chainlist.org).
+The existing ENSIP 9 relies on the existence of coin types on [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) which was designed to define address encoding type for deterministic wallets. As the majority of EVM-compatible chains inherit the same encoding type as Ethereum, it is redundant to keep requesting the addition of EVM-compatible chains into SLIP 44. This specification standardises a way to derive coinType based on [Chain ID](https://chainlist.org).
 
 ## Specification
 
@@ -84,14 +84,14 @@ You can also use existing functions formatsByName and formatsByCoinType to deriv
 
 The following EVM chains are the exception to this standard.
 
-* AVAX = AVAX has multiple chain address formats, and only c chain is EVM compatible
+* AVAX = AVAX has multiple chain address formats, and only c chain is EVM-compatible
 * RSK = RSK has its own additional validation
 
 They will continue using coinType defined at SLIP44
 
 ### Backwards Compatibility
 
-The following EVM compatible cointypes existed before introducing this new standard.
+The following EVM-compatible cointypes existed before introducing this new standard.
 
 * NRG
 * POA

--- a/docs/ensip/12.mdx
+++ b/docs/ensip/12.mdx
@@ -78,12 +78,12 @@ If a [data URL](https://datatracker.ietf.org/doc/html/rfc2397) is provided, it M
 
 A reference to an NFT may be used as an avatar URI, following the standards defined in [CAIP-22](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-22.md) and [CAIP-29](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-29.md).
 
-Clients MUST support at least ERC721 and ERC1155 type NFTs, and MAY support additional types of NFT.
+Clients MUST support at least ERC-721 and ERC-1155 type NFTs, and MAY support additional types of NFT.
 
 To resolve an NFT URI, a client follows this process:
 
 1. Retrieve the metadata URI for the token specified in the `avatar` field URI.
-2. Resolve the metadata URI, fetching the ERC721 or ERC1155 metadata.
+2. Resolve the metadata URI, fetching the ERC-721 or ERC-1155 metadata.
 3. Extract the image URL specified in the NFT metadata.
 4. Resolve the image URL and use it as the avatar.
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -56,7 +56,7 @@ Currently, registration costs are set at the following prices:
 
 3 and 4 character names have higher pricing to reflect the small number of these names available.
 
-To read more about the pricing structure of .eth names [read more about pricing](/registry/eth)
+To read more about the pricing structure of .eth names [read more about the pricing](/registry/eth)
 
 ### How long can I register a name for?
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -13,7 +13,7 @@ export const meta = {
 <div className="bg-ens-light-background-secondary dark:bg-ens-dark-background-secondary">
     <div className="max-w-5xl mx-auto space-y-4 py-16 px-4 sm:px-6">
         <h1>ENS Documentation</h1>
-        <p>Build applications with decentralized self-soverign identity.</p>
+        <p>Build applications with decentralized self-sovereign identity.</p>
         <div className="flex gap-3 flex-col sm:flex-row">
             <Button href="/web/quickstart">Get Started</Button>
             <Button variant="subtle" href="/learn/protocol">Learn about ENS</Button>


### PR DESCRIPTION
This pull request addresses various spelling and consistency issues across the documentation. The following corrections were made:

"checkout" has been changed to "check out" for proper usage in context.
"pull request" is now capitalized as "Pull Request" for consistency with standard terminology.
"EVM compatible" is corrected to "EVM-compatible" to reflect the correct hyphenation.
"non EVM" is updated to "non-EVM" for correct formatting and clarity.
"ERC721" and "ERC1155" have been corrected to "ERC-721" and "ERC-1155" to properly match the official standards.
"read more about pricing" has been modified to "read more about the pricing" to improve clarity and grammar.
"self-soverign" has been corrected to "self-sovereign" for accurate spelling.