### PR TITLE
Add Elixir Ethers library

### DIFF
--- a/app/src/components/Libraries.tsx
+++ b/app/src/components/Libraries.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
 import { FaJava, FaReact, FaRust } from 'react-icons/fa';
-import { SiDelphi, SiKotlin, SiNuget, SiPython } from 'react-icons/si';
+import { SiDelphi, SiElixir, SiKotlin, SiNuget, SiPython } from 'react-icons/si';
 import { TbBrandGolang, TbBrandJavascript } from 'react-icons/tb';
 
 type Language = {
@@ -160,6 +160,18 @@ export const ensLibraries: Language[] = [
             {
                 href: 'https://github.com/svanas/delphereum',
                 name: 'delphereum',
+                description: '',
+                logo: undefined, // -
+            },
+        ],
+    },
+    {
+        name: 'Elixir',
+        logo: <SiElixir />,
+        libraries: [
+            {
+                href: 'https://github.com/ExWeb3/elixir_ethers',
+                name: 'Ethers',
                 description: '',
                 logo: undefined, // -
             },


### PR DESCRIPTION
Hi,

This PR adds [Elixir Ethers](https://github.com/ExWeb3/elixir_ethers) library to the libraries section. Ethers directly implements [ENS Resolution](https://hexdocs.pm/ethers/Ethers.NameService.html) as part of its public API.

Thank you