### PR TITLE
fix: min_commitment_age language

### DIFF
--- a/docs/registry/eth.mdx
+++ b/docs/registry/eth.mdx
@@ -147,7 +147,7 @@ ETHRegistrarController.commit(commitment bytes32)
 ```
 
 Note this does require an on-chain transaction.
-After having committed it is recommended to wait at least the `MIN_COMMITMENT_AGE` (~60 seconds) before registering.
+After having committed it is required to wait at least the `MIN_COMMITMENT_AGE` (60 seconds) before registering.
 
 ### Registering
 


### PR DESCRIPTION
Spent several minutes chasing my tail until just going to look onchain and read the registrar logic. The minimum commitment age is enforced as a functional requirement to `commit`. Currently the docs mark it as "recommended" however that is not the case.