### PR TITLE
fix: incorrect resolver address on EthRegistryDemo

### DIFF
--- a/app/local/content/demos/ethregistry/ETHRegistryDemo.tsx
+++ b/app/local/content/demos/ethregistry/ETHRegistryDemo.tsx
@@ -30,7 +30,7 @@ const Demo = () => {
         '0x225f137127d9067788314bc7fcc1f36746a3c3B5'
     );
     const [resolver, setResolver] = useState(
-        '0xce01f8eee7E479C928F8919abD53E553a36CeF67'
+        '0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63'
     );
     const [duration, setDuration] = useState(60 * 60 * 24 * 365);
     const [secret, setSecret] = useState(

--- a/app/local/content/demos/ethregistry/ETHRegistryDemo.tsx
+++ b/app/local/content/demos/ethregistry/ETHRegistryDemo.tsx
@@ -30,7 +30,7 @@ const Demo = () => {
         '0x225f137127d9067788314bc7fcc1f36746a3c3B5'
     );
     const [resolver, setResolver] = useState(
-        '0x225f137127d9067788314bc7fcc1f36746a3c3B5'
+        '0xce01f8eee7E479C928F8919abD53E553a36CeF67'
     );
     const [duration, setDuration] = useState(60 * 60 * 24 * 365);
     const [secret, setSecret] = useState(


### PR DESCRIPTION
Before the owner and resolver were set to the same address while the set resolver address is just pointing to an EOA.

Updated to point to the `UniversalResolver` on mainnet.