### PR TITLE
Show DAO proposal titles in sidebar

### DIFF
--- a/scripts/ensips.ts
+++ b/scripts/ensips.ts
@@ -1,8 +1,9 @@
 import fs from 'fs/promises'
 import matter from 'gray-matter'
-import { Tokens, marked } from 'marked'
 import path from 'path'
 import { SidebarItem } from 'vocs'
+
+import { getFirstHeadingToken } from './utils'
 
 type DirectoryContents = {
   name: string
@@ -103,13 +104,6 @@ export async function ensips() {
       )
     )
   }
-}
-
-function getFirstHeadingToken(description: string) {
-  const tokens = marked.lexer(description)
-  return tokens.find(
-    (token) => token.type === 'heading' && token.depth === 1
-  ) as Tokens.Heading | undefined
 }
 
 function parseDate(date: Date | string) {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,0 +1,8 @@
+import { Tokens, marked } from 'marked'
+
+export function getFirstHeadingToken(description: string) {
+  const tokens = marked.lexer(description)
+  return tokens.find(
+    (token) => token.type === 'heading' && token.depth === 1
+  ) as Tokens.Heading | undefined
+}


### PR DESCRIPTION
Some people have requested this. It looks messy, but I agree that it's hard to find what you're looking for at first glance with the current number-only labels.

Before:
<img width="198" alt="image" src="https://github.com/user-attachments/assets/f2fb9f85-70fa-43ce-a842-8b171791290c" />

After:
<img width="278" alt="image" src="https://github.com/user-attachments/assets/c82edc08-e53e-4927-9d02-1c56d39919b9" />
