### PR TITLE
Add Plausible

### DIFF
--- a/functions/api/blah/event.ts
+++ b/functions/api/blah/event.ts
@@ -1,0 +1,7 @@
+// Plausible Proxy
+// https://plausible.io/docs/proxy/guides/cloudflare
+
+export function onRequestPost({ request }: { request: Request }) {
+  request.headers.delete('cookie')
+  return fetch('https://plausible.io/api/event', request)
+}

--- a/functions/api/blah/script.ts
+++ b/functions/api/blah/script.ts
@@ -1,0 +1,8 @@
+// Plausible Proxy
+// https://plausible.io/docs/proxy/guides/cloudflare
+
+const script = 'https://plausible.io/js/script.outbound-links.tagged-events.js'
+
+export function onRequestGet() {
+  return fetch(script)
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "4.0.7",
     "use-debounce": "^10.0.4",
+    "usehooks-ts": "^3.1.1",
     "viem": "^2.22.8",
     "vite": "^6.2.7",
     "vocs": "1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       use-debounce:
         specifier: ^10.0.4
         version: 10.0.4(react@19.1.0)
+      usehooks-ts:
+        specifier: ^3.1.1
+        version: 3.1.1(react@19.1.0)
       viem:
         specifier: ^2.22.8
         version: 2.22.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -2809,6 +2812,9 @@ packages:
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -3976,6 +3982,12 @@ packages:
     resolution: {integrity: sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  usehooks-ts@3.1.1:
+    resolution: {integrity: sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==}
+    engines: {node: '>=16.15.0'}
+    peerDependencies:
+      react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   utf-8-validate@5.0.10:
     resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
@@ -7536,6 +7548,8 @@ snapshots:
 
   lodash-es@4.17.21: {}
 
+  lodash.debounce@4.0.8: {}
+
   lodash@4.17.21: {}
 
   log-symbols@5.1.0:
@@ -8998,6 +9012,11 @@ snapshots:
 
   use-sync-external-store@1.4.0(react@19.1.0):
     dependencies:
+      react: 19.1.0
+
+  usehooks-ts@3.1.1(react@19.1.0):
+    dependencies:
+      lodash.debounce: 4.0.8
       react: 19.1.0
 
   utf-8-validate@5.0.10:

--- a/src/components/EnsipHeader.tsx
+++ b/src/components/EnsipHeader.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function EnsipHeader({ authors, created, status }: Props) {
   return (
-    <div className="flex flex-col gap-1">
+    <div className="ensip-header flex flex-col gap-1">
       <p>
         <strong>Authors:</strong> {authors.join(', ')}
       </p>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -18,8 +18,8 @@ const ArrowIcon: FC<ComponentProps<'svg'>> = (properties) => {
 const variantStyles = {
   primary: 'bg-blue text-white hover:bg-blue-bright',
   disabled: 'bg-grey-light text-grey',
-  destructive: 'bg-red text-white hover:bg-red-bright',
-  success: 'bg-green text-white hover:bg-green-bright',
+  destructive: '!bg-red text-white hover:!bg-red-bright',
+  success: '!bg-green text-white hover:!bg-green-bright',
   outline:
     'ring-2 ring-inset ring-grey-active text-grey-active hover:ring-grey hover:text-grey',
 }

--- a/src/footer.tsx
+++ b/src/footer.tsx
@@ -1,14 +1,16 @@
-import { useState } from 'react'
+import { useLocalStorage } from 'usehooks-ts'
 
 import { Button } from './components/ui/Button'
 
 export default function Footer() {
-  const [selectedResponse, setSelectedResponse] = useState<'yes' | 'no' | null>(
-    null
-  )
+  const [selectedResponse, setSelectedResponse] = usePageFeedback()
 
   const isYesSelected = selectedResponse === 'yes'
   const isNoSelected = selectedResponse === 'no'
+
+  // Don't show the footer on the home page
+  if (typeof window !== 'undefined' && window.location.pathname === '/')
+    return null
 
   return (
     <div className="hidden flex-col gap-3 sm:flex sm:flex-row sm:items-center sm:justify-between">
@@ -21,9 +23,12 @@ export default function Footer() {
           aria-label="Did you find this page useful? Yes"
           aria-pressed={isYesSelected}
           onClick={() => {
+            // Don't track if the user has already selected this response
+            if (isYesSelected) return
+
             setSelectedResponse('yes')
             ;(window as any).plausible?.('Page Useful', {
-              props: { response: 'yes', url: window.location.href },
+              props: { response: 'Yes' },
             })
           }}
         >
@@ -34,9 +39,12 @@ export default function Footer() {
           aria-label="Did you find this page useful? No"
           aria-pressed={isNoSelected}
           onClick={() => {
+            // Don't track if the user has already selected this response
+            if (isNoSelected) return
+
             setSelectedResponse('no')
             ;(window as any).plausible?.('Page Useful', {
-              props: { response: 'no', url: window.location.href },
+              props: { response: 'No' },
             })
           }}
         >
@@ -45,4 +53,29 @@ export default function Footer() {
       </div>
     </div>
   )
+}
+
+type FeedbackResponse = 'yes' | 'no'
+type FeedbackMap = Record<string, FeedbackResponse>
+
+function usePageFeedback() {
+  const [map, setMap] = useLocalStorage<FeedbackMap>(
+    'ensdocs:page-feedback',
+    {}
+  )
+
+  const urlKey = typeof window !== 'undefined' ? window.location.pathname : ''
+
+  const selectedResponse = (map[urlKey] ?? null) as FeedbackResponse | null
+
+  const setSelectedResponse = (response: FeedbackResponse | null) => {
+    setMap((prev) => {
+      const next = { ...(prev || {}) }
+      if (response) next[urlKey] = response
+      else delete next[urlKey]
+      return next
+    })
+  }
+
+  return [selectedResponse, setSelectedResponse] as const
 }

--- a/src/footer.tsx
+++ b/src/footer.tsx
@@ -28,7 +28,7 @@ export default function Footer() {
 
             setSelectedResponse('yes')
             ;(window as any).plausible?.('Page Useful', {
-              props: { response: 'Yes' },
+              props: { response: 'yes' },
             })
           }}
         >
@@ -44,7 +44,7 @@ export default function Footer() {
 
             setSelectedResponse('no')
             ;(window as any).plausible?.('Page Useful', {
-              props: { response: 'No' },
+              props: { response: 'no' },
             })
           }}
         >

--- a/src/footer.tsx
+++ b/src/footer.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+
+import { Button } from './components/ui/Button'
+
+export default function Footer() {
+  const [selectedResponse, setSelectedResponse] = useState<'yes' | 'no' | null>(
+    null
+  )
+
+  const isYesSelected = selectedResponse === 'yes'
+  const isNoSelected = selectedResponse === 'no'
+
+  return (
+    <div className="hidden flex-col gap-3 sm:flex sm:flex-row sm:items-center sm:justify-between">
+      <div className="text-base font-medium">
+        Did you find this page useful?
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant={isYesSelected ? 'success' : 'outline'}
+          aria-label="Did you find this page useful? Yes"
+          aria-pressed={isYesSelected}
+          onClick={() => {
+            setSelectedResponse('yes')
+            ;(window as any).plausible?.('Page Useful', {
+              props: { response: 'yes', url: window.location.href },
+            })
+          }}
+        >
+          Yes
+        </Button>
+        <Button
+          variant={isNoSelected ? 'destructive' : 'outline'}
+          aria-label="Did you find this page useful? No"
+          aria-pressed={isNoSelected}
+          onClick={() => {
+            setSelectedResponse('no')
+            ;(window as any).plausible?.('Page Useful', {
+              props: { response: 'no', url: window.location.href },
+            })
+          }}
+        >
+          No
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -152,3 +152,10 @@ th.vocs_TableHeader > code.vocs_Code {
   color: unset;
   font-size: unset;
 }
+
+/* Remove bottom border on the page header when it's followed by the ENSIP header block */
+.vocs_Content > .vocs_Header:has(+ .ensip-header) {
+  margin-bottom: var(--vocs-space_16) !important;
+  padding-bottom: 0 !important;
+  border-bottom: none !important;
+}

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -67,28 +67,24 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [remarkMermaid],
   },
-  head: (
-    <>
-      {/* Plausible Analytics behind a proxy */}
-      <script
-        defer
-        data-domain="docs.ens"
-        data-api={`${baseUrl}/api/blah/event`}
-        src={`${baseUrl}/api/blah/script`}
-      ></script>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }`,
-        }}
-      ></script>
-
-      <style>{`
-          .vocs_Link {
-            background: red !important;
-          }
-        `}</style>
-    </>
-  ),
+  head() {
+    // Plausible Analytics behind a proxy
+    return (
+      <>
+        <script
+          defer
+          data-domain="docs.ens"
+          data-api="/api/blah/event"
+          src="/api/blah/script"
+        ></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }`,
+          }}
+        ></script>
+      </>
+    )
+  },
   sidebar: [
     {
       text: 'Intro',

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -67,21 +67,42 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [remarkMermaid],
   },
-  head: {
+  head({ path }) {
+    const BaseScript = ({ children }: React.PropsWithChildren) => (
+      <>
+        <script
+          defer
+          data-domain="docs.ens"
+          src="https://plausible.io/js/script.outbound-links.tagged-events.js"
+        ></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }`,
+          }}
+        ></script>
+
+        {children}
+      </>
+    )
+
     // TODO: Ideally this should get injected into <header> for semantics via a remark plugin.
     // Overriding styles will look the same and is easier for now.
     // https://vocs.dev/docs/api/config#markdownremarkplugins
-    '/ensip/': (
-      <>
-        <style>{`
+    if (path.includes('/ensip/')) {
+      return (
+        <BaseScript>
+          <style>{`
           .vocs_Header {
             margin-bottom: var(--vocs-space_16) !important;
             padding-bottom: 0 !important;
             border-bottom: none !important;
           }
         `}</style>
-      </>
-    ),
+        </BaseScript>
+      )
+    }
+
+    return <BaseScript />
   },
   sidebar: [
     {

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -69,10 +69,12 @@ export default defineConfig({
   },
   head: (
     <>
+      {/* Plausible Analytics behind a proxy */}
       <script
         defer
         data-domain="docs.ens"
-        src="https://plausible.io/js/script.outbound-links.tagged-events.js"
+        data-api="/api/blah/event"
+        src="/api/blah/script"
       ></script>
       <script
         dangerouslySetInnerHTML={{

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -73,8 +73,8 @@ export default defineConfig({
       <script
         defer
         data-domain="docs.ens"
-        data-api="/api/blah/event"
-        src="/api/blah/script"
+        data-api={`${baseUrl}/api/blah/event`}
+        src={`${baseUrl}/api/blah/script`}
       ></script>
       <script
         dangerouslySetInnerHTML={{

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -67,43 +67,26 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [remarkMermaid],
   },
-  head({ path }) {
-    const BaseScript = ({ children }: React.PropsWithChildren) => (
-      <>
-        <script
-          defer
-          data-domain="docs.ens"
-          src="https://plausible.io/js/script.outbound-links.tagged-events.js"
-        ></script>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }`,
-          }}
-        ></script>
+  head: (
+    <>
+      <script
+        defer
+        data-domain="docs.ens"
+        src="https://plausible.io/js/script.outbound-links.tagged-events.js"
+      ></script>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }`,
+        }}
+      ></script>
 
-        {children}
-      </>
-    )
-
-    // TODO: Ideally this should get injected into <header> for semantics via a remark plugin.
-    // Overriding styles will look the same and is easier for now.
-    // https://vocs.dev/docs/api/config#markdownremarkplugins
-    if (path.includes('/ensip/')) {
-      return (
-        <BaseScript>
-          <style>{`
-          .vocs_Header {
-            margin-bottom: var(--vocs-space_16) !important;
-            padding-bottom: 0 !important;
-            border-bottom: none !important;
+      <style>{`
+          .vocs_Link {
+            background: red !important;
           }
         `}</style>
-        </BaseScript>
-      )
-    }
-
-    return <BaseScript />
-  },
+    </>
+  ),
   sidebar: [
     {
       text: 'Intro',


### PR DESCRIPTION
Adds [Plausible](https://plausible.io/) for analytics. Puts their script and `/event` endpoint behind a proxy via Cloudflare Pages Functions [so that Adblockers don't block tracking](https://plausible.io/docs/proxy/introduction).

Also adds a "Did you find this page useful?" section to the bottom of every page, of which the responses get tracked as custom events in Plausible.