### PR TITLE
Add Cookbook (demo)

### DIFF
--- a/src/components/AskCookbook.tsx
+++ b/src/components/AskCookbook.tsx
@@ -1,0 +1,15 @@
+///** It's a public API key, so it's safe to expose it here */
+const COOKBOOK_PUBLIC_API_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NmJlNWY2ZDZkMjk4YjBkZjY5YTRmYjAiLCJpYXQiOjE3MjM3NTIzMDEsImV4cCI6MjAzOTMyODMwMX0.VramSR-VHSbgdQfscWvoahAuYMhLbc8i1_7wW50z_IU'
+
+export function AskCookbook() {
+  return (
+    <>
+      <div id="__cookbook" data-api-key={COOKBOOK_PUBLIC_API_KEY}></div>
+      <script
+        src="https://cdn.jsdelivr.net/npm/@cookbookdev/docsbot/dist/standalone/index.cjs.js"
+        defer
+      ></script>
+    </>
+  )
+}

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -4,6 +4,8 @@ import { IntercomProvider } from 'react-use-intercom'
 import { WagmiProvider, createConfig, http } from 'wagmi'
 import { mainnet } from 'wagmi/chains'
 
+import { AskCookbook } from './components/AskCookbook'
+
 const config = createConfig({
   chains: [mainnet],
   transports: {
@@ -21,6 +23,7 @@ export default function Layout({ children }: PropsWithChildren) {
           {children}
         </QueryClientProvider>
       </IntercomProvider>
+      <AskCookbook />
     </WagmiProvider>
   )
 }


### PR DESCRIPTION
Revisiting #361 

It would overlap with the Intercom widget in production, so we either have to drop Intercom or customize the positioning.