### PR TITLE
Add degov to the DAO page

### DIFF
--- a/src/pages/dao/index.mdx
+++ b/src/pages/dao/index.mdx
@@ -12,6 +12,7 @@
 - [**Snapshot**](https://snapshot.org/#/ens.eth): For offchain proposals.
 - [**Agora**](https://agora.ensdao.org): For onchain proposals and token delegation.
 - [**Tally**](https://www.withtally.com/governance/ens): For onchain proposals and token delegation.
+- [**DeGov**](https://ens.degov.ai): For onchain proposals and token delegation.
 
 ## Onboarding & Participation
 


### PR DESCRIPTION
Provide another portal for the ENS DAO governance system https://ens.degov.ai. Also see the post in the forum https://discuss.ens.domains/t/ens-dao-is-now-live-on-degov/21404