### PR TITLE
Add contract deployments

### DIFF
--- a/scripts/deployments.ts
+++ b/scripts/deployments.ts
@@ -7,7 +7,7 @@ type Deployment = {
   address?: Hex
   github: {
     filename: string
-    srcPath: string
+    srcPath?: string
   }
 }
 
@@ -45,10 +45,16 @@ let DEPLOYMENTS: DeploymentsByChain[] = [
         },
       },
       {
-        name: 'ETH Registrar Controller',
+        name: 'ETH Registrar Controller (Latest)',
         github: {
           filename: 'ETHRegistrarController',
           srcPath: 'contracts/ethregistrar/',
+        },
+      },
+      {
+        name: 'Wrapped ETH Registrar Controller',
+        github: {
+          filename: 'WrappedETHRegistrarController',
         },
       },
       {
@@ -59,9 +65,16 @@ let DEPLOYMENTS: DeploymentsByChain[] = [
         },
       },
       {
-        name: 'Reverse Registrar',
+        name: 'L1 Reverse Registrar',
         github: {
           filename: 'ReverseRegistrar',
+          srcPath: 'contracts/reverseRegistrar/',
+        },
+      },
+      {
+        name: 'Default Reverse Registrar',
+        github: {
+          filename: 'DefaultReverseRegistrar',
           srcPath: 'contracts/reverseRegistrar/',
         },
       },
@@ -121,9 +134,16 @@ let DEPLOYMENTS: DeploymentsByChain[] = [
         },
       },
       {
-        name: 'Reverse Registrar',
+        name: 'L1 Reverse Registrar',
         github: {
           filename: 'ReverseRegistrar',
+          srcPath: 'contracts/reverseRegistrar/',
+        },
+      },
+      {
+        name: 'Default Reverse Registrar',
+        github: {
+          filename: 'DefaultReverseRegistrar',
           srcPath: 'contracts/reverseRegistrar/',
         },
       },
@@ -183,9 +203,16 @@ let DEPLOYMENTS: DeploymentsByChain[] = [
         },
       },
       {
-        name: 'Reverse Registrar',
+        name: 'L1 Reverse Registrar',
         github: {
           filename: 'ReverseRegistrar',
+          srcPath: 'contracts/reverseRegistrar/',
+        },
+      },
+      {
+        name: 'Default Reverse Registrar',
+        github: {
+          filename: 'DefaultReverseRegistrar',
           srcPath: 'contracts/reverseRegistrar/',
         },
       },

--- a/src/components/ContractDeployments.tsx
+++ b/src/components/ContractDeployments.tsx
@@ -1,7 +1,7 @@
 import { AnchorHTMLAttributes } from 'react'
 
+import { DeploymentsByChain } from '../../scripts/deployments'
 import deploymentsJson from '../data/generated/deployments.json' with { type: 'any' }
-import { DeploymentsByChain } from '../plugins/deployments'
 
 const deploymentsByChain = deploymentsJson as DeploymentsByChain[]
 
@@ -31,11 +31,13 @@ export function ContractDeployments({
                   >
                     ABI
                   </VocsExternalLink>
-                  <VocsExternalLink
-                    href={`https://github.com/ensdomains/ens-contracts/blob/staging/${contract.github.srcPath}/${contract.github.filename}.sol`}
-                  >
-                    Source
-                  </VocsExternalLink>
+                  {contract.github.srcPath && (
+                    <VocsExternalLink
+                      href={`https://github.com/ensdomains/ens-contracts/blob/staging/${contract.github.srcPath}/${contract.github.filename}.sol`}
+                    >
+                      Source
+                    </VocsExternalLink>
+                  )}
                 </div>
               </td>
               <td className="vocs_TableCell font-mono">{contract.address}</td>

--- a/src/pages/learn/deployments.mdx
+++ b/src/pages/learn/deployments.mdx
@@ -31,7 +31,7 @@ However, resolution needs to start somewhere, so the entrypoint for resolution i
 
 ## Deployments
 
-Listed below you will find a list of latest deployments of registries, resolvers, and more.
+Below you will find an abbreviated list of our latest contract deployments. The source of truth for ENS contract deployments is the [ensdomains/ens-contracts](https://github.com/ensdomains/ens-contracts/tree/staging/deployments) repository.
 
 ### Mainnet
 


### PR DESCRIPTION
Clarifying "Reverse Registrar" as "L1 Reverse Registrar" and adding DefaultReverseRegistrar. I'm intentionally not adding DefaultReverseResolver or [Chain]ReverseResolver's because devs don't interact with them directly in any way.

We should probably add L2 ReverseRegistrars but I'm saving that for the future since it makes the page a lot longer if the same format is kept, and they're already listed [here](https://docs.ens.domains/registry/reverse).