### PR TITLE
Add ethers.js patch note to ENSv2 readiness page

### DIFF
--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -4,9 +4,9 @@ ENSv2 introduces a redesigned architecture and improved multi-chain interoperabi
 
 The good news? For most applications, preparing for ENSv2 is as simple as updating to the latest version of a [supported library](/web/libraries). At the time of writing, not all libraries have added ENSv2 support yet. Here's the current status:
 
-- [viem >= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350)
-- ethers.js: Not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens)
-- web3.js: Deprecated
+- **viem:** [>= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350).
+- **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
+- **web3.js:** Deprecated.
 
 :::info
 **Using a supported library? You're done!** Everything is handled automatically.


### PR DESCRIPTION
This PR adds a note for the ethers.js v5/v6 monkey patch to the ENSv2 readiness page.