### PR TITLE
Link ENSIP titles to their individual pages in the intro table

### DIFF
--- a/scripts/ensips.ts
+++ b/scripts/ensips.ts
@@ -96,6 +96,7 @@ export async function ensips() {
       JSON.stringify(
         sortedSidebar.map((s) => ({
           title: s.text,
+          link: s.link,
           status: s.status.charAt(0).toUpperCase() + s.status.slice(1),
         })),
         null,

--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -18,8 +18,8 @@ export function Table({ columns, rows }: Props) {
         </tr>
       </thead>
       <tbody>
-        {rows.map((row) => (
-          <tr key={row.join('-')} className="vocs_TableRow">
+        {rows.map((row, rowIndex) => (
+          <tr key={rowIndex} className="vocs_TableRow">
             {row.map((cell, index) => (
               <td className="vocs_TableCell" key={index}>
                 {cell}

--- a/src/pages/ensip/index.mdx
+++ b/src/pages/ensip/index.mdx
@@ -10,7 +10,7 @@ Improvement Proposals have included anything from new contract features, to text
 
 <Table
   columns={['Title', 'Status']}
-  rows={ensips.map((ensip) => [ensip.title, ensip.status])}
+  rows={ensips.map((ensip) => [<a href={ensip.link}>{ensip.title}</a>, ensip.status])}
 />
 
 ## Propose an ENSIP


### PR DESCRIPTION
Add link field to generated ensips.json and render ENSIP titles as anchor links in the table on /ensip/. Also fix Table component key to use row index instead of join() which breaks with JSX elements.

https://claude.ai/code/session_01P5JtkbvFaV4pZrM8Bzrf3k