### PR TITLE
Add current stewards section to rules

### DIFF
--- a/src/pages/dao/wg/rules.mdx
+++ b/src/pages/dao/wg/rules.mdx
@@ -109,3 +109,26 @@ The numbering system of EP's was changed after Working Group rules were establis
 ## 12. Amendments
 
 1. These rules may be amended at any time by passing a Social Proposal. For an example of a social proposal to amend these rules, see [EP 4.8](https://snapshot.box/#/s:ens.eth/proposal/0x26a5c8dec547837495707e70446d1e7cd874a91f75753c602998f6e70083a266).
+
+## 13. Current Stewards (as of March 2026)
+
+The stewards listed below were elected for the 2025 Term (Term 6) and are serving in an extended capacity during the ENS DAO Retrospective cycle (elections for the next term are scheduled to begin in April 2026). Lead Stewards are noted where appointed. All information is sourced from the official ENS DAO Stewards documentation and recent Working Group announcements on the ENS governance forum (discuss.ens.domains).
+
+DAO Secretary: limes.eth (@limes on Discourse)
+
+Meta-Governance Working Group
+
+Lead Steward: Alex / netto.eth (@netto.eth on Discourse)
+Spence / 5pence.eth (@5pence.eth on Discourse)
+Cam / daostrat.eth (@daostrat.eth on Discourse)
+ENS Ecosystem Working Group
+
+Lead Steward: Donnie / daemon.eth (@don.nie on Discourse)
+slobo.eth (@slobo.eth on Discourse)
+limes.eth (@limes on Discourse) — also serves as DAO Secretary
+Public Goods Working Group
+
+Lead Steward: simona.eth (@simona_pop on Discourse)
+coltron.eth (@Coltron.eth on Discourse)
+sovereignsignal.eth (@sov on Discourse)
+Note: Discourse usernames link to the ENS governance forum (e.g., https://discuss.ens.domains/u/[username]). .eth handles are the primary ENS names used for identification and compensation. Stewards manage their respective working group multi-sigs and operations in accordance with the Working Group Rules. For the latest updates, refer to the ENS DAO Stewards page or the Extended Term 6 Dashboard.


### PR DESCRIPTION
This pull request adds an updated section to the working group rules page, listing the current ENS DAO stewards as of March 2026 and clarifying their roles during the Retrospective cycle. The new section includes detailed steward assignments for each working group, notes on identification and responsibilities, and references to official documentation and forums.

Updates to steward information and documentation:

* Added a "Current Stewards" section specifying the 2025 Term (Term 6) stewards, their roles (including lead stewards and DAO Secretary), and their extended service during the Retrospective cycle, with Discourse and ENS handle references.
* Provided links to official ENS DAO Stewards documentation, the Extended Term 6 Dashboard, and cited recent governance forum announcements for transparency and verification.
* Included explanatory notes on how to identify stewards and the scope of their responsibilities within the DAO.Added current stewards and working group details for the 2025 Term.