### PR TITLE
Add ENS MCP by Namespace

### DIFF
--- a/src/pages/building-with-ai.mdx
+++ b/src/pages/building-with-ai.mdx
@@ -99,7 +99,7 @@ The community has built additional MCP servers that may be useful for ENS and gr
 
 - **[ETHID MCP](https://ethidentitykit.com/docs/ai-tools/ethid-mcp)** - Tools for working with ENS and EFP
 - **[Ethereum MCP](https://github.com/gskril/ethereum-mcp)** - General-purpose EVM tools including ENS resolution, ABI parsing, and more
-- **[ENS MCP](https://github.com/thenamespace/ens-mcp)** - Lets AI agents query ENS names, subnames, ownership, profiles, pricing, availability, and history.
+- **[ENS MCP by Namespace](https://github.com/thenamespace/ens-mcp)** - Lets AI agents query ENS names, subnames, ownership, profiles, pricing, availability, and history.
 
 These are independently maintained by community members. Check their documentation for installation instructions and available features.
 

--- a/src/pages/building-with-ai.mdx
+++ b/src/pages/building-with-ai.mdx
@@ -99,6 +99,7 @@ The community has built additional MCP servers that may be useful for ENS and gr
 
 - **[ETHID MCP](https://ethidentitykit.com/docs/ai-tools/ethid-mcp)** - Tools for working with ENS and EFP
 - **[Ethereum MCP](https://github.com/gskril/ethereum-mcp)** - General-purpose EVM tools including ENS resolution, ABI parsing, and more
+- **[ENS MCP](https://github.com/thenamespace/ens-mcp)** - Lets AI agents query ENS names, subnames, ownership, profiles, pricing, availability, and history.
 
 These are independently maintained by community members. Check their documentation for installation instructions and available features.
 


### PR DESCRIPTION
Our ENS MCP is already live in production with 2 products - Web3Identity and ENScribe, and is steadily gaining traction (14 GitHub stars and growing). Given that it’s actively used and will be continuously maintained by the Namespace team, it would be great to include it in the official ENS documentation as a supported integration path.