### PR TITLE
Simplify ENSIPs file inlining regex + error response body

### DIFF
--- a/scripts/ensips.ts
+++ b/scripts/ensips.ts
@@ -36,7 +36,12 @@ export async function ensips() {
       'https://api.github.com/repos/ensdomains/ensips/contents/ensips',
       { headers: githubHeaders }
     )
-    if (!ensipsRepoRes.ok) throw new Error('Failed to fetch ENSIPs')
+    if (!ensipsRepoRes.ok) {
+      const body = await ensipsRepoRes.text()
+      throw new Error(
+        `Failed to fetch ENSIPs: ${ensipsRepoRes.status} ${ensipsRepoRes.statusText} — ${body}`
+      )
+    }
     const files = ((await ensipsRepoRes.json()) as DirectoryContents).filter(
       (f) => f.name.endsWith('.md')
     )

--- a/scripts/ensips.ts
+++ b/scripts/ensips.ts
@@ -173,7 +173,8 @@ async function inlineSubdirectoryFiles(
   markdown: string,
   ensipNumber: number
 ): Promise<string> {
-  const subfileLink = /^\[[^\]]*\]\(\.\/\d+\/([^)]+\.md)\)$/gm
+  // Matches [](./NUMBER/file.md) — content inclusion directives
+  const subfileLink = /^\[\]\(\.\/\d+\/([^)]+\.md)\)$/gm
   let result = markdown
 
   for (const match of markdown.matchAll(subfileLink)) {

--- a/scripts/ensips.ts
+++ b/scripts/ensips.ts
@@ -173,15 +173,11 @@ async function inlineSubdirectoryFiles(
   markdown: string,
   ensipNumber: number
 ): Promise<string> {
-  // Replace lines containing links to subdirectory .md files
-  // (e.g. "- [text](./19/supported.md)") with the actual file content.
-  // Matches the entire line to avoid leftover list markers.
-  const subfileLink =
-    /^[^\S\n]*(?:[-*]|\d+\.)\s*\[([^\]]*)\]\(\.\/\d+\/([^)]+\.md)\)\s*$/gm
+  const subfileLink = /^\[[^\]]*\]\(\.\/\d+\/([^)]+\.md)\)$/gm
   let result = markdown
 
   for (const match of markdown.matchAll(subfileLink)) {
-    const [fullMatch, , filename] = match
+    const [fullMatch, filename] = match
     const url = `https://raw.githubusercontent.com/ensdomains/ensips/master/ensips/${ensipNumber}/${filename}`
     const res = await fetchWithRetry(url)
 


### PR DESCRIPTION
Drop list marker requirement to match new `[](./<ensip>/<file>.md)` convention + passing response body on error.