### PR TITLE
Support mid-line file inclusions in ENSIPs generation

### DIFF
--- a/scripts/ensips.ts
+++ b/scripts/ensips.ts
@@ -179,7 +179,7 @@ async function inlineSubdirectoryFiles(
   ensipNumber: number
 ): Promise<string> {
   // Matches [](./NUMBER/file.md) — content inclusion directives
-  const subfileLink = /^\[\]\(\.\/\d+\/([^)]+\.md)\)$/gm
+  const subfileLink = /\[\]\(\.\/\d+\/([^)]+\.md)\)/gm
   let result = markdown
 
   for (const match of markdown.matchAll(subfileLink)) {


### PR DESCRIPTION
Removes line anchors from the subdirectory file inclusion regex in `ensips.ts` so `[](./N/file.md)` works mid-line (e.g. inlining a version string), not just as a standalone line.