### PR TITLE
 Add web3j and go-ens to ENSv2 readiness, credit library maintainers

### DIFF
--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -120,7 +120,7 @@ const ensLibraries: Language[] = [
         href: 'https://github.com/wealdtech/go-ens',
         name: 'go-ens',
         description:
-          'Go bindings for ENS contracts and resolution. Maintained by Bitwise Investments.',
+          'Go bindings for ENS contracts and resolution. Maintained by Bitwise.',
         logo: undefined,
       },
       {

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -117,6 +117,13 @@ const ensLibraries: Language[] = [
     logo: <TbBrandGolang />,
     libraries: [
       {
+        href: 'https://github.com/wealdtech/go-ens',
+        name: 'go-ens',
+        description:
+          'Go bindings for ENS contracts and resolution. Maintained by Bitwise Investments.',
+        logo: undefined,
+      },
+      {
         href: 'https://github.com/wealdtech/ethereal',
         name: 'ethereal',
         description: '',

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -37,7 +37,8 @@ const ensLibraries: Language[] = [
       {
         href: 'https://viem.sh/',
         name: 'Viem',
-        description: '',
+        description:
+          'TypeScript interface for Ethereum. Maintained by wevm.',
         logo: undefined,
       },
       {
@@ -81,7 +82,7 @@ const ensLibraries: Language[] = [
         href: 'https://github.com/ethereum/web3.py',
         name: 'web3.py',
         description:
-          'A python interface for interacting with the Ethereum blockchain and ecosystem.',
+          'A python interface for interacting with the Ethereum blockchain and ecosystem. Maintained by ApeWorX.',
         logo: undefined,
       },
     ],

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -105,7 +105,8 @@ const ensLibraries: Language[] = [
       {
         href: 'https://docs.web3j.io/',
         name: 'web3j',
-        description: '',
+        description:
+          'Lightweight Java and Android library for integration with Ethereum clients. Maintained by Web3 Labs.',
         logo: '/img/libraries/web3j.png',
       },
     ],

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -8,6 +8,7 @@ The good news? For most applications, preparing for ENSv2 is as simple as updati
 - **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01) (maintained by [ApeWorX](https://www.apeworx.io/)).
 - **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) (maintained by [Web3 Labs](https://www.web3labs.com/web3j-sdk)).
 - **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
+- **[go-ens](https://github.com/wealdtech/go-ens):** Pending (maintained by [Bitwise Investments](https://bitwiseinvestments.com)).
 - **web3.js:** Deprecated.
 
 :::info

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -8,7 +8,7 @@ The good news? For most applications, preparing for ENSv2 is as simple as updati
 - **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01) (maintained by [ApeWorX](https://www.apeworx.io/)).
 - **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) (maintained by [Web3 Labs](https://www.web3labs.com/web3j-sdk)).
 - **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
-- **[go-ens](https://github.com/wealdtech/go-ens):** Pending (maintained by [Bitwise Investments](https://bitwiseinvestments.com)).
+- **[go-ens](https://github.com/wealdtech/go-ens):** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49) (maintained by [Bitwise Investments](https://bitwiseinvestments.com)).
 - **web3.js:** Deprecated.
 
 :::info

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -4,8 +4,8 @@ ENSv2 introduces a redesigned architecture and improved multi-chain interoperabi
 
 The good news? For most applications, preparing for ENSv2 is as simple as updating to the latest version of a [supported library](/web/libraries). At the time of writing, not all libraries have added ENSv2 support yet. Here's the current status:
 
-- **viem:** [>= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350).
-- **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01).
+- **viem:** [>= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350) (maintained by [wevm](https://wevm.dev/)).
+- **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01) (maintained by [ApeWorX](https://www.apeworx.io/)).
 - **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) (maintained by [Web3 Labs](https://www.web3labs.com/web3j-sdk)).
 - **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
 - **web3.js:** Deprecated.

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -6,6 +6,7 @@ The good news? For most applications, preparing for ENSv2 is as simple as updati
 
 - **viem:** [>= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350).
 - **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01).
+- **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) (maintained by [Web3 Labs](https://www.web3labs.com/web3j-sdk)).
 - **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
 - **web3.js:** Deprecated.
 

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -4,11 +4,11 @@ ENSv2 introduces a redesigned architecture and improved multi-chain interoperabi
 
 The good news? For most applications, preparing for ENSv2 is as simple as updating to the latest version of a [supported library](/web/libraries). At the time of writing, not all libraries have added ENSv2 support yet. Here's the current status:
 
-- **viem:** [>= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350) (maintained by [wevm](https://wevm.dev/)).
-- **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01) (maintained by [ApeWorX](https://www.apeworx.io/)).
-- **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) (maintained by [Web3 Labs](https://www.web3labs.com/web3j-sdk)).
+- **viem:** [>= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350) ([wevm](https://wevm.dev/)).
+- **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01) ([ApeWorX](https://www.apeworx.io/)).
+- **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) ([Web3 Labs](https://www.web3labs.com/web3j-sdk)).
 - **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
-- **go-ens:** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49) (maintained by [Bitwise](https://bitwiseinvestments.com)).
+- **go-ens:** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49) ([Bitwise](https://bitwiseinvestments.com)).
 - **web3.js:** Deprecated.
 
 :::info

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -8,7 +8,7 @@ The good news? For most applications, preparing for ENSv2 is as simple as updati
 - **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01) (maintained by [ApeWorX](https://www.apeworx.io/)).
 - **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) (maintained by [Web3 Labs](https://www.web3labs.com/web3j-sdk)).
 - **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
-- **[go-ens](https://github.com/wealdtech/go-ens):** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49) (maintained by [Bitwise Investments](https://bitwiseinvestments.com)).
+- **go-ens:** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49) (maintained by [Bitwise Investments](https://bitwiseinvestments.com)).
 - **web3.js:** Deprecated.
 
 :::info

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -8,7 +8,7 @@ The good news? For most applications, preparing for ENSv2 is as simple as updati
 - **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01) (maintained by [ApeWorX](https://www.apeworx.io/)).
 - **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) (maintained by [Web3 Labs](https://www.web3labs.com/web3j-sdk)).
 - **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
-- **go-ens:** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49) (maintained by [Bitwise Investments](https://bitwiseinvestments.com)).
+- **go-ens:** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49) (maintained by [Bitwise](https://bitwiseinvestments.com)).
 - **web3.js:** Deprecated.
 
 :::info

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -4,11 +4,11 @@ ENSv2 introduces a redesigned architecture and improved multi-chain interoperabi
 
 The good news? For most applications, preparing for ENSv2 is as simple as updating to the latest version of a [supported library](/web/libraries). At the time of writing, not all libraries have added ENSv2 support yet. Here's the current status:
 
-- **viem:** [>= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350) ([wevm](https://wevm.dev/)).
-- **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01) ([ApeWorX](https://www.apeworx.io/)).
-- **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true) ([Web3 Labs](https://www.web3labs.com/web3j-sdk)).
+- **viem:** [>= v2.35.0](https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2350).
+- **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01).
+- **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true).
 - **ethers.js:** Native support not published yet. [Work in progress on v6.16.0](https://github.com/ethers-io/ethers.js/tree/wip-v6.16.0-ens). In the meantime, an [ENS ethers patch](https://github.com/ensdomains/ethers-patch) is available for both v5 and v6. Follow the instructions in the repository to apply it.
-- **go-ens:** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49) ([Bitwise](https://bitwiseinvestments.com)).
+- **go-ens:** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49).
 - **web3.js:** Deprecated.
 
 :::info


### PR DESCRIPTION
## Summary

  - Add **web3j** to the ENSv2 readiness list (ready from
  [v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true), maintained by
  [Web3 Labs](https://www.web3labs.com/web3j-sdk)).
  - Add **go-ens** to the libraries listing and mark it as work-in-progress on the
  readiness list (tracking
  [wealdtech/go-ens#49](https://github.com/wealdtech/go-ens/pull/49), maintained by
  [Bitwise](https://bitwiseinvestments.com)).
  - Credit maintainers for the libraries already listed on the readiness page: viem
  ([wevm](https://wevm.dev/)), web3.py ([ApeWorX](https://www.apeworx.io/)).

  ## Test plan

  - [x] `bun run dev` and visit `/web/ensv2-readiness` — verify web3j and go-ens rows
  render with the correct links and maintainer credits.
  - [x] Visit `/web/libraries` — verify the new go-ens card appears in the Go section.