### PR TITLE
Update Working Group Rules for Term 7 (EP 6.44)

### DIFF
--- a/src/pages/dao/wg/rules.mdx
+++ b/src/pages/dao/wg/rules.mdx
@@ -1,6 +1,6 @@
 # ENS DAO Working Group Rules
 
-_This document represents the current state of the Working Group Rules as created by [EP0.4](https://snapshot.box/#/s:ens.eth/proposal/0x899ead1d9b9b98f63f6a60dc0939bef55dbe365e78c6a550f07be969a47f148b), and amended by [EP1.8](https://snapshot.box/#/s:ens.eth/proposal/0xc7186cf8bebe47600f8d847e76f7971ea97b48bc04eda1e07780aff91fb6410d) and [EP4.8](https://snapshot.box/#/s:ens.eth/proposal/0x26a5c8dec547837495707e70446d1e7cd874a91f75753c602998f6e70083a266). These should represent the canonical version of the rules and any social proposal to amend it should include a PR to this document._
+_This document represents the current state of the Working Group Rules as created by [EP0.4](https://snapshot.box/#/s:ens.eth/proposal/0x899ead1d9b9b98f63f6a60dc0939bef55dbe365e78c6a550f07be969a47f148b), and amended by [EP1.8](https://snapshot.box/#/s:ens.eth/proposal/0xc7186cf8bebe47600f8d847e76f7971ea97b48bc04eda1e07780aff91fb6410d), [EP4.8](https://snapshot.box/#/s:ens.eth/proposal/0x26a5c8dec547837495707e70446d1e7cd874a91f75753c602998f6e70083a266), and [EP6.44](https://snapshot.box/#/s:ens.eth/proposal/0xe4e1c052b2ea4f640cab27ddec326df6290d8996a9219b60cda4c4d4509f5f9a). These should represent the canonical version of the rules and any social proposal to amend it should include a PR to this document._
 
 :::note
 The numbering system of EP's was changed after Working Group rules were established, which is why the above proposals have different numbers than Snapshot displays.
@@ -53,8 +53,9 @@ The numbering system of EP's was changed after Working Group rules were establis
 ## 7. Removal and Replacement of Stewards
 
 1.  Stewards may be removed at any time by:
-    1. a Social Proposal passed by the DAO; or
-    2. a simple indicative majority vote among Stewards of all working groups, with the outcome of that vote communicated in the relevant working group category of the ENS governance forum.
+    1. a Social Proposal passed by the DAO;
+    2. a simple indicative majority vote among Stewards of all working groups, with the outcome of that vote communicated in the relevant working group category of the ENS governance forum; or
+    3. a two-thirds vote among the elected Stewards of a single working group, with the outcome of that vote communicated in the relevant working group category of the ENS governance forum.
 2.  Stewards may step down from their position at any time by communicating their intention to step down in the ENS governance forum.
 3.  In the event that a Steward is removed, steps down, or is unable to continue as a Steward, for whatever reason, prior to the end of a Term, a new election must be held to fill any vacant Steward positions, in accordance with rule 6 above.
 
@@ -75,7 +76,7 @@ The numbering system of EP's was changed after Working Group rules were establis
 
 ## 9. DAO Secretary
 
-1.  At the start of each Term, the current Stewards of each working group shall collaborate to appoint an individual who will serve as the secretary of the DAO (hereafter 'Secretary' or 'Secretaries').
+1.  At the start of each Term, the current Stewards of each working group may collaborate to appoint an individual who will serve as the secretary of the DAO (hereafter 'Secretary' or 'Secretaries'). Where only a single working group exists, the Stewards of that working group may elect not to appoint a Secretary. If no Secretary is appointed for a Term, rules 9.2 through 9.8 shall not apply for that Term, and the administrative duties otherwise set out in rule 9.8 (other than multi-sig keyholding, which is governed by rule 10.3) shall be carried out collectively by the Stewards of the working group.
 2.  The Secretary may be appointed or removed from that role at any time by a majority vote of all elected Stewards in a given Term with the outcome of that vote communicated in the ENS governance forum.
 3.  The Secretary will remain in that position, as Secretary of the DAO, from the date of appointment until the end of a given Term or until the date at which they are removed from that position in accordance with rule 9.2 above.
 4.  Secretaries are eligible to receive fair compensation for their work as Secretary of the DAO.
@@ -94,8 +95,8 @@ The numbering system of EP's was changed after Working Group rules were establis
    1. In order for a working group to have a funding request included in a Collective Proposal submitted to the DAO during a Funding Window, the funding request must have passed as a Social Proposal in the same Funding Window.
    2. In the case of an emergency, where working group funds are needed by a working group outside of a Funding Window, an executable proposal, as defined by the ENS governance documentation, may be submitted at any time by a Steward of a working group to request funds from the DAO.
 2. Working group funds requested and approved in accordance with rule 10.1 above are to be paid out into separate working group multi-sigs controlled by the DAO.
-3. Each working group multi-sig must have four keyholders, made up of three current elected Stewards for that working group and the Secretary of the DAO for that Term, with no other keyholders permitted.
-4. Working group funds may be disbursed from working group multi-sigs with three-of-four keyholder signing.
+3. Each working group multi-sig must have four keyholders, made up of three current elected Stewards for that working group and the Secretary of the DAO for that Term, with no other keyholders permitted. Where no Secretary has been appointed for a Term in accordance with rule 9.1 above, the multi-sig for the sole working group shall instead have three keyholders, made up of the three current elected Stewards for that working group, with no other keyholders permitted.
+4. Working group funds may be disbursed from working group multi-sigs with three-of-four keyholder signing, or with two-of-three keyholder signing in the case of a three-keyholder multi-sig as defined in rule 10.3 above.
 5. Stewards of a given working group shall have the discretion to reallocate funds approved in a Collective Proposal where appropriate and where it is not in conflict with any rules of the DAO, DAO bylaws, or the ENS DAO constitution.
 
 ## 11. Compensation for Stewards and Lead Stewards


### PR DESCRIPTION
Updating the Working Group Rules following [EP 6.44](https://snapshot.box/#/s:ens.eth/proposal/0xe4e1c052b2ea4f640cab27ddec326df6290d8996a9219b60cda4c4d4509f5f9a), which passed with Option 4 (Metagov only).

This dissolves the Public Goods and Ecosystem working groups, leaving Meta-Governance as the only WG, and amends rules 7.1, 9.1, 10.3 and 10.4 accordingly.

The stewards page update is left for the start of Term 7 (July 1).
