### PR TITLE
Fix missing og:image social previews

### DIFF
--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -26,7 +26,7 @@ export default defineConfig({
   iconUrl: '/img/icon.svg',
   logoUrl: '/img/logo-mark.svg',
   baseUrl,
-  ogImageUrl: baseUrl ? `${baseUrl}/api/og?title=%title` : undefined,
+  ogImageUrl: baseUrl ? { '/': `${baseUrl}/api/og?title=%title` } : undefined,
   banner: {
     content: (
       <p>


### PR DESCRIPTION
## Problem
Link previews for `docs.ens.domains` (X, Slack, etc.) show no image. The rendered HTML contains no `og:image` / `twitter:image` meta tag on any page, even though the `/api/og` endpoint works and returns a valid PNG.
  
## Cause
vocs (1.4.1) only emits the `og:image`/`twitter:image` tags when `ogImageUrl` is given in its path-keyed **object** form. Its `useOgImageUrl` hook returns `undefined` for a plain **string** value (the string branch is unreachable), so the tags are silently dropped. Our config passed a string, so they were never rendered.
  
## Fix
Wrap the URL in the object form (`{ '/': ... }`); the `'/'` key matches every path. The `baseUrl` gate is kept so preview/local builds still behave correctly.