### PR TITLE
Standardize proposal titling, numbering, and formatting conventions

### DIFF
--- a/src/components/ProposalValidator.tsx
+++ b/src/components/ProposalValidator.tsx
@@ -25,15 +25,22 @@ const TYPE_TAG_PATTERN =
 
 const TEMP_CHECK_PATTERN = /\[\s*temp\s*check\s*\]/i
 
-function parseHeadings(markdown: string): Heading[] {
+type ParsedDocument = {
+  headings: Heading[]
+  // Lines that consist entirely of bold text, likely intended as headings
+  boldHeadings: Array<{ text: string; line: number }>
+}
+
+function parseDocument(markdown: string): ParsedDocument {
   const headings: Heading[] = []
+  const boldHeadings: ParsedDocument['boldHeadings'] = []
   const lines = markdown.split('\n')
   let codeFence: string | null = null
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
 
-    // Skip headings inside fenced code blocks
+    // Skip content inside fenced code blocks
     const fenceMatch = line.match(/^\s{0,3}(`{3,}|~{3,})/)
     if (fenceMatch) {
       if (!codeFence) codeFence = fenceMatch[1][0]
@@ -49,10 +56,16 @@ function parseHeadings(markdown: string): Heading[] {
         text: headingMatch[2].trim(),
         line: i + 1,
       })
+      continue
+    }
+
+    const boldMatch = line.match(/^\s{0,3}(\*\*|__)(.+?)\1\s*$/)
+    if (boldMatch && !/\*\*|__/.test(boldMatch[2])) {
+      boldHeadings.push({ text: boldMatch[2].trim(), line: i + 1 })
     }
   }
 
-  return headings
+  return { headings, boldHeadings }
 }
 
 // Pasting from some tools produces literal "\n" sequences instead of real
@@ -69,7 +82,7 @@ export function beautify(markdown: string): string {
 
 export function validate(markdown: string): Finding[] {
   const findings: Finding[] = []
-  const headings = parseHeadings(markdown)
+  const { headings, boldHeadings } = parseDocument(markdown)
   const h1s = headings.filter((h) => h.level === 1)
 
   // A proposal needs headings, but zero H1s is fine: Snapshot and the forum
@@ -148,6 +161,15 @@ export function validate(markdown: string): Finding[] {
         line: curr.line,
       })
     }
+  }
+
+  // Bold text on its own line is usually a heading in disguise
+  for (const bold of boldHeadings) {
+    findings.push({
+      level: 'warning',
+      message: `Bold text used as a heading ("${bold.text}"). Use a markdown heading (\`##\`) instead — bold is for emphasis, not structure.`,
+      line: bold.line,
+    })
   }
 
   // Expected sections

--- a/src/components/ProposalValidator.tsx
+++ b/src/components/ProposalValidator.tsx
@@ -1,0 +1,230 @@
+import { useMemo, useState } from 'react'
+
+import { cn } from '../lib/utils'
+
+type Finding = {
+  level: 'error' | 'warning'
+  message: string
+  line?: number
+}
+
+type Heading = {
+  level: number
+  text: string
+  line: number
+}
+
+const EXPECTED_SECTIONS = ['Abstract', 'Motivation', 'Specification']
+
+// Matches self-assigned EP numbers like "[7.1]", "[EP 7.1]" or "EP 7.1"
+const EP_NUMBER_PATTERN = /\[\s*(ep\s*)?\d+(\.\d+)*\s*\]|\bep\s*\d+(\.\d+)+/i
+
+// Matches type tags like "[Executable]" or "[Social]"
+const TYPE_TAG_PATTERN =
+  /\[\s*(executable|social|constitutional amendment)\s*\]/i
+
+const TEMP_CHECK_PATTERN = /\[\s*temp\s*check\s*\]/i
+
+function parseHeadings(markdown: string): Heading[] {
+  const headings: Heading[] = []
+  const lines = markdown.split('\n')
+  let codeFence: string | null = null
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Skip headings inside fenced code blocks
+    const fenceMatch = line.match(/^\s{0,3}(`{3,}|~{3,})/)
+    if (fenceMatch) {
+      if (!codeFence) codeFence = fenceMatch[1][0]
+      else if (fenceMatch[1][0] === codeFence) codeFence = null
+      continue
+    }
+    if (codeFence) continue
+
+    const headingMatch = line.match(/^\s{0,3}(#{1,6})\s+(.*?)\s*#*\s*$/)
+    if (headingMatch) {
+      headings.push({
+        level: headingMatch[1].length,
+        text: headingMatch[2].trim(),
+        line: i + 1,
+      })
+    }
+  }
+
+  return headings
+}
+
+// Pasting from some tools produces literal "\n" sequences instead of real
+// newlines, which makes the whole document parse as a single line. Convert
+// them (and literal tabs) to the real characters so the text can be parsed.
+export function beautify(markdown: string): string {
+  const literalNewlines = (markdown.match(/\\n/g) || []).length
+  const realNewlines = (markdown.match(/\n/g) || []).length
+  if (literalNewlines > 2 && literalNewlines > realNewlines) {
+    return markdown.replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+  }
+  return markdown
+}
+
+export function validate(markdown: string): Finding[] {
+  const findings: Finding[] = []
+  const headings = parseHeadings(markdown)
+  const h1s = headings.filter((h) => h.level === 1)
+
+  // A proposal needs headings, but zero H1s is fine: Snapshot and the forum
+  // have a separate title field that acts as the H1, so those bodies should
+  // start at H2
+  if (headings.length === 0) {
+    findings.push({
+      level: 'error',
+      message:
+        'No headings found. The document should have a single H1 (`# Title`) followed by H2 sections — or start directly at H2 if the title is set in a separate field, as on Snapshot and the forum.',
+    })
+  }
+
+  if (h1s.length > 1) {
+    for (const h1 of h1s.slice(1)) {
+      findings.push({
+        level: 'error',
+        message: `Multiple H1 headings. Only the title should be an H1 — change "${h1.text}" to an H2 (\`##\`).`,
+        line: h1.line,
+      })
+    }
+  }
+
+  const title = h1s[0]
+
+  if (title) {
+    // The H1 should be the first heading in the document
+    if (headings[0] !== title) {
+      findings.push({
+        level: 'error',
+        message:
+          'The title (H1) should be the first heading in the document, before any sections.',
+        line: title.line,
+      })
+    }
+
+    // No self-assigned EP numbers
+    if (EP_NUMBER_PATTERN.test(title.text)) {
+      findings.push({
+        level: 'error',
+        message:
+          'The title contains an EP number. Remove it — the canonical number is assigned automatically once the proposal is posted for a vote.',
+        line: title.line,
+      })
+    }
+
+    // No type tags
+    const typeTag = title.text.match(TYPE_TAG_PATTERN)
+    if (typeTag) {
+      findings.push({
+        level: 'error',
+        message: `The title contains a type tag ("${typeTag[0]}"). Remove it — the type is inferred from where the vote is posted.`,
+        line: title.line,
+      })
+    }
+
+    // Temp check prefix is only for forum drafts
+    if (TEMP_CHECK_PATTERN.test(title.text)) {
+      findings.push({
+        level: 'warning',
+        message:
+          'The title has a [Temp Check] prefix. This is correct for forum drafts, but remove it before posting the proposal to Snapshot or the governor contract.',
+        line: title.line,
+      })
+    }
+  }
+
+  // No skipped heading levels (e.g. H2 followed by H4)
+  for (let i = 1; i < headings.length; i++) {
+    const prev = headings[i - 1]
+    const curr = headings[i]
+    if (curr.level > prev.level + 1) {
+      findings.push({
+        level: 'warning',
+        message: `Heading level skips from H${prev.level} to H${curr.level} at "${curr.text}". Headings should only go one level deeper at a time.`,
+        line: curr.line,
+      })
+    }
+  }
+
+  // Expected sections
+  const h2Texts = headings
+    .filter((h) => h.level === 2)
+    .map((h) => h.text.toLowerCase())
+
+  for (const section of EXPECTED_SECTIONS) {
+    if (!h2Texts.includes(section.toLowerCase())) {
+      findings.push({
+        level: 'warning',
+        message: `Missing a "${section}" section. Proposals typically include \`## ${section}\`.`,
+      })
+    }
+  }
+
+  return findings.sort((a, b) => {
+    if (a.level !== b.level) return a.level === 'error' ? -1 : 1
+    return (a.line ?? Infinity) - (b.line ?? Infinity)
+  })
+}
+
+export function ProposalValidator() {
+  const [markdown, setMarkdown] = useState('')
+  const findings = useMemo(() => validate(markdown), [markdown])
+
+  return (
+    <div className="flex flex-col gap-4">
+      <textarea
+        value={markdown}
+        onChange={(e) => setMarkdown(beautify(e.target.value))}
+        placeholder={
+          '# Do Something Cool\n\n## Abstract\n\n## Motivation\n\n## Specification'
+        }
+        rows={10}
+        spellCheck={false}
+        className="border-border placeholder:text-text-disabled w-full resize-y rounded-md border px-4 py-3 font-mono text-sm transition-all outline-none focus-visible:border-[var(--vocs-color_borderAccent)]"
+      />
+
+      {markdown.trim() !== '' &&
+        (findings.length === 0 ? (
+          <div className="border-green-light bg-green-surface text-green-dim rounded-md border px-4 py-3 text-sm font-medium">
+            No issues found
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {findings.map((finding, i) => (
+              <div
+                key={i}
+                className={cn(
+                  'flex items-baseline gap-3 rounded-md border px-4 py-3 text-sm',
+                  finding.level === 'error'
+                    ? 'border-red-light bg-red-surface'
+                    : 'border-yellow-light bg-yellow-surface'
+                )}
+              >
+                <span
+                  className={cn(
+                    'shrink-0 font-semibold uppercase',
+                    finding.level === 'error' ? 'text-red' : 'text-yellow-dim'
+                  )}
+                >
+                  {finding.level}
+                </span>
+                <span>
+                  {finding.message}
+                  {finding.line !== undefined && (
+                    <span className="text-text-secondary">
+                      {' '}
+                      (line {finding.line})
+                    </span>
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+    </div>
+  )
+}

--- a/src/pages/dao/governance/process.mdx
+++ b/src/pages/dao/governance/process.mdx
@@ -65,33 +65,29 @@ There are three main types of governance proposals you can make:
 
 The purpose of the Temperature Check is to determine if there is sufficient will to make changes to the status quo.
 
-To create a Temperature Check, ask a general, non-biased question to the community on [discuss.ens.domains](https://discuss.ens.domains) about a potential change (example: “Should ENS decrease registration costs for 3-letter domains?”). Forum posts should be in the "DAO-wide -> Temperature Check" category.
+To create a Temperature Check, ask a general, non-biased question to the community on [discuss.ens.domains](https://discuss.ens.domains) about a potential change (example: “Should ENS decrease registration costs for 3-letter domains?”). Forum posts should be in the "DAO-wide -> Temperature Check" category and titled with a `[Temp Check]` prefix (see [Titles and Proposal Numbers](/dao/proposals/submit#titles-and-proposal-numbers)).
 
 Temperature checks are informal and optional; it's up to you to use the feedback to decide if you want to proceed further with your proposal.
 
-### **Phase 2: Draft Proposal — GitHub**
+### **Phase 2: Draft Proposal — Discourse**
 
 The purpose of the Draft Proposal is to establish formal discussion around a potential proposal.
 
-To create a Draft Proposal, [create a new governance proposal](https://github.com/ensdomains/governance-docs/new/main/governance-proposals) in the governance-docs repository on GitHub. Start by copying the template for an [executable proposal](executable-proposal-template.md), [social proposal](social-proposal-template.md), or [constitutional amendment](constitutional-amendment-template.md), as appropriate. Once you have written your proposal, create a Draft Pull Request for it. Start a new post in the DAO-wide -> Draft Proposals" category with a link to the PR for discussion.
+To create a Draft Proposal, start by copying the template for an [executable proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md), [social proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md), or [constitutional amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md), as appropriate. Once you have written your proposal, post it in the "DAO-wide -> Draft Proposals" category on [discuss.ens.domains](https://discuss.ens.domains). While the proposal remains a draft, keep the `[Temp Check]` prefix on the forum post title.
 
-Reach out to your network to build support for the proposal. Discuss the proposal and solicit delegates to provide feedback on it. Be willing to respond to questions on the Draft Proposal topic and in comments on the pull request. Share your viewpoint, although try to remain as impartial as possible.
+Reach out to your network to build support for the proposal. Discuss the proposal and solicit delegates to provide feedback on it. Be willing to respond to questions on the Draft Proposal topic. Share your viewpoint, although try to remain as impartial as possible.
 
 If your proposal is an executable proposal, you will need to specify the actions your proposal will take while it is in draft stage. You may wish to wait until the proposal is stable before doing this. The executable proposal template explains how to do this.
 
-If your proposal is a constitutional amendment, you will need to produce a diff showing the exact changes you are proposing to make. The easiest way to do this is to go to the [constitution](/dao/constitution), click "Edit on GitHub", then click the pencil icon to edit the document in a fork. You can then create a pull request via the GitHub UI and include this in your proposal. You should do this in a separate branch to your draft proposal; while the proposal will be merged as soon as it goes to a vote, the amendment will only be merged if the proposal passes.
+If your proposal is a constitutional amendment, you will need to produce a diff showing the exact changes you are proposing to make to the [constitution](/dao/constitution), and include it in your proposal.
 
 Once you are confident the proposal is in a stable state, you can proceed to phase 3.
 
 ### **Phase 3: Active Proposal — Snapshot / Governance Portal**
 
-Use GitHub to flag your PR as Ready for Review. A contributor will:
+Once discussion has settled, the proposal can be posted for a vote. Remember to title the vote with the plain proposal title — no `[Temp Check]` prefix, no EP number, and no type tag. The canonical EP number is assigned automatically once the vote is posted, as described in [Titles and Proposal Numbers](/dao/proposals/submit#titles-and-proposal-numbers).
 
-1. Merge your PR if it meets the requirements.
-2. Assign your proposal a proposal number in the form EP###.
-3. Schedule the proposal for a snapshot vote.
-
-If your proposal is a Social Proposal or a Constitutional Amendment, that's it! If the snapshot vote passes, the proposal is passed and you are done.
+If your proposal is a Social Proposal or a Constitutional Amendment, it is posted to [Snapshot](https://vote.ensdao.org) for an offchain vote. That's it! If the snapshot vote passes, the proposal is passed and you are done.
 
 If your proposal is an Executable Proposal, you will now need to submit it to the governor contract for voting onchain.
 

--- a/src/pages/dao/governance/process.mdx
+++ b/src/pages/dao/governance/process.mdx
@@ -55,48 +55,46 @@ RFPs all follow this process:
 
 ### Types of Proposal
 
-There are three main types of governance proposals you can make:
+There are three types of governance proposal:
 
-1. **[Executable Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md):** This is a proposal for a series of smart contract operations to be executed by accounts the DAO controls. These can include transfers of tokens as well as arbitrary smart contract calls. Examples of this include allocating funding to a workstream multisig wallet, or upgrading an ENS core contract. Executable proposals have a quorum requirement of 1% and require a minimum approval of 50% to pass.
-2. **[Social Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md)**: This is a proposal that asks for the agreement of the DAO on something that cannot be enforced onchain. Examples of this include a proposal to change the royalty percentage for the ENS secondary market on OpenSea, or a petition to the root keyholders. Social proposals have a quorum requirement of 1% and require a minimum approval of 50% to pass.
-3. **[Constitutional Amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md)**: This is a social proposal that asks the DAO to amend the constitution. Your draft proposal should include a [diff](https://en.wikipedia.org/wiki/Diff) showing the exact changes you propose to make to the constitution. Rules for amending the constitution are set in the constitution itself, and currently require a quorum of 1% and a minimum approval of two thirds to pass.
+1. **[Executable Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md)**: A series of smart contract operations to be executed by accounts the DAO controls — token transfers or arbitrary contract calls, such as funding a working group multisig or upgrading a core ENS contract. Requires a 1% quorum and 50% approval to pass.
+2. **[Social Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md)**: Asks for the DAO's agreement on something that can't be enforced onchain, such as changing the royalty percentage for the ENS secondary market on OpenSea, or a petition to the root keyholders. Requires a 1% quorum and 50% approval to pass.
+3. **[Constitutional Amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md)**: A social proposal that amends the [constitution](/dao/constitution). Rules for amending the constitution are set in the constitution itself — currently a 1% quorum and two-thirds approval.
 
-### **Phase 1: Temperature Check — Discourse**
+### Phase 1: Temperature Check — Discourse
 
-The purpose of the Temperature Check is to determine if there is sufficient will to make changes to the status quo.
+A Temperature Check gauges whether there is sufficient will to change the status quo.
 
-To create a Temperature Check, ask a general, non-biased question to the community on [discuss.ens.domains](https://discuss.ens.domains) about a potential change (example: “Should ENS decrease registration costs for 3-letter domains?”). Forum posts should be in the "DAO-wide -> Temperature Check" category and titled with a `[Temp Check]` prefix (see [Titles and Proposal Numbers](/dao/proposals/submit#titles-and-proposal-numbers)).
+Ask a general, non-biased question on [discuss.ens.domains](https://discuss.ens.domains) about a potential change (e.g. "Should ENS decrease registration costs for 3-letter domains?"). Post in the "DAO-wide -> Temperature Check" category with a `[Temp Check]` title prefix (see [Titles and Proposal Numbers](/dao/proposals/submit#titles-and-proposal-numbers)).
 
-Temperature checks are informal and optional; it's up to you to use the feedback to decide if you want to proceed further with your proposal.
+Temperature checks are informal and optional — use the feedback to decide whether to proceed.
 
-### **Phase 2: Draft Proposal — Discourse**
+### Phase 2: Draft Proposal — Discourse
 
-The purpose of the Draft Proposal is to establish formal discussion around a potential proposal.
+A Draft Proposal establishes formal discussion around a concrete proposal.
 
-To create a Draft Proposal, start by copying the template for an [executable proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md), [social proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md), or [constitutional amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md), as appropriate. Once you have written your proposal, post it in the "DAO-wide -> Draft Proposals" category on [discuss.ens.domains](https://discuss.ens.domains). While the proposal remains a draft, keep the `[Temp Check]` prefix on the forum post title.
+Copy the template for an [executable proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md), [social proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md), or [constitutional amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md), write your proposal, and post it in the "DAO-wide -> Draft Proposals" category on [discuss.ens.domains](https://discuss.ens.domains). Keep the `[Temp Check]` prefix on the title while it remains a draft.
 
-Reach out to your network to build support for the proposal. Discuss the proposal and solicit delegates to provide feedback on it. Be willing to respond to questions on the Draft Proposal topic. Share your viewpoint, although try to remain as impartial as possible.
+Build support: reach out to your network, solicit feedback from delegates, and respond to questions on the topic — while staying as impartial as you can.
 
-If your proposal is an executable proposal, you will need to specify the actions your proposal will take while it is in draft stage. You may wish to wait until the proposal is stable before doing this. The executable proposal template explains how to do this.
+Executable proposals must specify the onchain actions they will take before going to a vote; the template explains how. You may want to wait until the proposal is stable to do this.
 
-If your proposal is a constitutional amendment, you will need to produce a diff showing the exact changes you are proposing to make to the [constitution](/dao/constitution), and include it in your proposal.
+Constitutional amendments must include a [diff](https://en.wikipedia.org/wiki/Diff) showing the exact changes to the [constitution](/dao/constitution).
 
-Once you are confident the proposal is in a stable state, you can proceed to phase 3.
+Once the proposal is stable, proceed to phase 3.
 
-### **Phase 3: Active Proposal — Snapshot / Governance Portal**
+### Phase 3: Active Proposal — Snapshot / Governance Portal
 
-Once discussion has settled, the proposal can be posted for a vote. Remember to title the vote with the plain proposal title — no `[Temp Check]` prefix, no EP number, and no type tag. The canonical EP number is assigned automatically once the vote is posted, as described in [Titles and Proposal Numbers](/dao/proposals/submit#titles-and-proposal-numbers).
+Once discussion has settled, the proposal is posted for a vote. Title the vote with the plain proposal title — no `[Temp Check]` prefix, no EP number, no type tag. The canonical EP number is assigned automatically at this point, as described in [Titles and Proposal Numbers](/dao/proposals/submit#titles-and-proposal-numbers).
 
-If your proposal is a Social Proposal or a Constitutional Amendment, it is posted to [Snapshot](https://vote.ensdao.org) for an offchain vote. That's it! If the snapshot vote passes, the proposal is passed and you are done.
+Social Proposals and Constitutional Amendments are posted to [Snapshot](https://vote.ensdao.org) for an offchain vote. That's it — if the vote passes, you're done.
 
-If your proposal is an Executable Proposal, you will now need to submit it to the governor contract for voting onchain.
+Executable Proposals are instead submitted to the governor contract for an onchain vote:
 
-To enact an Executable Proposal:
+1. Ensure at least 100k ENS is delegated to your address, or find a delegate who meets the proposal threshold to propose on your behalf.
+2. Call the `propose()` function on the ENS governor at [governor.ensdao.eth](https://etherscan.io/address/0x323a76393544d5ecca80cd6ef2a560c6a395b7e3).
 
-1. Ensure at least 100k ENS is delegated to your address in order to submit a proposal, or find a delegate who has enough delegated ENS to meet the proposal threshold to propose on your behalf.
-2. Call the propose() function of the ENS governor (at [governor.ensdao.eth](https://etherscan.io/address/0x323a76393544d5ecca80cd6ef2a560c6a395b7e3)) to deploy your proposal.
-
-Once the propose() function has been called, a seven day voting period is started. Ongoing discussion can take place on your proposal post. If the proposal passes successfully, a two day timelock will follow before the proposed code is executed.
+This starts a seven-day voting period, during which discussion can continue on the forum topic. If the proposal passes, a two-day timelock follows before the proposed code is executed.
 
 ## **Governance Terminology**
 

--- a/src/pages/dao/proposals/submit.mdx
+++ b/src/pages/dao/proposals/submit.mdx
@@ -1,49 +1,47 @@
 import { ProposalValidator } from '../../../components/ProposalValidator'
 
-# Process of Submitting a Proposal
+# Submitting a Proposal
 
-## Passing a Proposal
+## Types of Proposal
 
-### Types of Proposal
+There are three types of governance proposal:
 
-There are three main types of governance proposals you can make:
+1. **[Executable Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md)**: A series of smart contract operations to be executed by accounts the DAO controls — token transfers or arbitrary contract calls, such as funding a working group multisig or upgrading a core ENS contract. Requires a 1% quorum and 50% approval to pass.
+2. **[Social Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md)**: Asks for the DAO's agreement on something that can't be enforced onchain, such as changing the royalty percentage for the ENS secondary market on OpenSea, or a petition to the root keyholders. Requires a 1% quorum and 50% approval to pass.
+3. **[Constitutional Amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md)**: A social proposal that amends the [constitution](/dao/constitution). Rules for amending the constitution are set in the constitution itself — currently a 1% quorum and two-thirds approval.
 
-1. **[Executable Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md):** This is a proposal for a series of smart contract operations to be executed by accounts the DAO controls. These can include transfers of tokens as well as arbitrary smart contract calls. Examples of this include allocating funding to a workstream multisig wallet, or upgrading an ENS core contract. Executable proposals have a quorum requirement of 1% and require a minimum approval of 50% to pass.
-2. **[Social Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md)**: This is a proposal that asks for the agreement of the DAO on something that cannot be enforced onchain. Examples of this include a proposal to change the royalty percentage for the ENS secondary market on OpenSea, or a petition to the root keyholders. Social proposals have a quorum requirement of 1% and require a minimum approval of 50% to pass.
-3. **[Constitutional Amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md)**: This is a social proposal that asks the DAO to amend the constitution. Your draft proposal should include a [diff](https://en.wikipedia.org/wiki/Diff) showing the exact changes you propose to make to the constitution. Rules for amending the constitution are set in the constitution itself, and currently require a quorum of 1% and a minimum approval of two thirds to pass.
+## Titles and Proposal Numbers
 
-### Titles and Proposal Numbers
+A proposal's title should contain **only the title itself** — no EP number and no type tag like `[Executable]` or `[Social]`.
 
-A proposal's title should contain **only the title of the proposal** — no proposal number and no type tag like `[Executable]` or `[Social]`.
+Since the DAO's second working group term, most proposals have self-assigned an EP ("ENS Proposal") number and type tag in the title (e.g. "[7.1] [Social] SPP3: Marketplace RFP"). Because titles are free text, this broke down in practice: unrelated proposals have used duplicate numbers, some funding proposals were split into sub-numbers like 6.6.1 while others weren't, and formatting varies from title to title.
 
-Since the DAO's second working group term, most proposals have self-assigned an EP ("ENS Proposal") number in their title, along with a type tag (e.g. "[7.1] [Social] SPP3: Marketplace RFP"). Because titles are free text, this convention can't be enforced and has broken down in practice: duplicate numbers have been used by unrelated proposals, some funding proposals have been split into sub-numbers like 6.6.1 and 6.6.2 while others haven't, and spacing between the number and the type tag varies from proposal to proposal.
+Neither piece of metadata belongs in the title, because both can be derived objectively:
 
-Neither piece of metadata needs to be in the title, because both can be derived objectively:
+- **The EP number** is assigned automatically when the proposal is posted for a vote (see below).
+- **The type** is inferred from where the vote takes place: the [governor contract](https://etherscan.io/address/0x323a76393544d5ecca80cd6ef2a560c6a395b7e3) means Executable, Snapshot means Social.
 
-- **The EP number** is assigned deterministically based on when the proposal is posted for a vote (see below).
-- **The proposal type** is inferred from where the vote takes place: proposals submitted to the [governor contract](https://etherscan.io/address/0x323a76393544d5ecca80cd6ef2a560c6a395b7e3) are Executable Proposals, and proposals posted to Snapshot are Social Proposals.
+The one exception is a temp check prefix while the proposal is still a draft on the forum:
 
-The only decoration a title should ever carry is a temp check prefix while the proposal is still being discussed on the forum:
+- When first sharing a draft on the forum, prepend `[Temp Check]` and a space to the title: "[Temp Check] Do Something Cool".
+- When posting to Snapshot or the governor contract, use the plain title: "Do Something Cool". Ideally, remove the prefix from the forum topic at this point too.
 
-- When first sharing a draft proposal on the forum, prepend `[Temp Check]` followed by a space to the title, e.g. "[Temp Check] Do Something Cool".
-- When posting the proposal to Snapshot or the governor contract, use the plain title with no prefix, e.g. "Do Something Cool". At this point, ideally edit the forum topic to remove the `[Temp Check]` prefix there too.
+### How EP numbers are assigned
 
-#### How EP numbers are assigned
+Offchain platforms such as this site assign each proposal a canonical number of the form `{termNumber}.{proposalNumber}`: the working group term in which the vote is posted, and a counter that increments with each vote posted during that term. Each platform displays the number and inferred type as it sees fit — these docs reconstruct titles like "[EP 7.1] [Executable] Do Something Cool".
 
-Offchain systems such as this documentation site assign each proposal a canonical number of the form `{termNumber}.{proposalNumber}`, where `termNumber` is the working group term in which the vote is posted and `proposalNumber` increments sequentially in the order proposals are posted for a vote within that term. Each system may then display the number and inferred type however it sees fit — these docs reconstruct titles in the format "[EP 7.1] [Executable] Do Something Cool".
+This system takes effect July 14, 2026. Earlier proposals keep their EP numbers — the [proposals directory in this repository](https://github.com/ensdomains/docs/tree/master/src/pages/dao/proposals) is the canonical list of numbers assigned to date.
 
-This system takes effect as of July 14, 2026. Proposals posted before that date keep their existing EP numbers and will not be renumbered — the [proposals directory in the docs repository](https://github.com/ensdomains/docs/tree/master/src/pages/dao/proposals) serves as the canonical list of EP numbers assigned to date.
+A few details:
 
-A few clarifications on how numbering works:
+- A proposal is only numbered once it is posted for a vote. Drafts and temp checks are not.
+- Numbers are never reused. A defeated or cancelled proposal keeps its number, and a resubmission gets the next one.
+- A Snapshot vote and an onchain vote are always separate proposals with separate numbers, even when they concern the same matter (e.g. a social vote followed by an executable vote implementing it).
+- Related proposals voted on separately (e.g. a funding request split into multiple votes) are just separate proposals with sequential numbers. Never construct sub-numbers like 6.6.1 — those only exist in older proposals.
 
-- A proposal only receives its number once it is posted for a vote. Drafts and temp checks are not numbered.
-- Numbers are never reused. A proposal that is defeated or cancelled keeps its number, and a resubmission is a new proposal that receives the next number.
-- A Snapshot vote and an onchain vote are always separate proposals with separate numbers, even if they concern the same matter (e.g. a social vote followed by an executable vote implementing its outcome).
-- Related proposals voted on separately (e.g. a funding request split into multiple votes) are simply separate proposals, each receiving the next sequential number. Do not construct sub-numbers like 6.6.1 — that scheme appears in older proposals for historical reasons only.
+## Formatting
 
-### Formatting
-
-Proposals are written in markdown, and semantic heading structure matters: many past proposals use multiple H1s, which renders weirdly on governance apps, hurts SEO, and hurts accessibility. A document should have at most one H1 — the proposal title — followed by H2 headings for each section:
+Proposals are written in markdown, and heading structure matters: multiple H1s render weirdly on governance apps and hurt SEO and accessibility. A document should have at most one H1 — the title — followed by H2 sections:
 
 ```md
 # Title
@@ -55,45 +53,43 @@ Proposals are written in markdown, and semantic heading structure matters: many 
 ## Specification
 ```
 
-When the platform provides a separate title field, that field is the H1. Snapshot proposals and forum posts both work this way, so their bodies should contain no H1 at all — the largest heading should be an H2.
+When a platform provides a separate title field, that field is the H1. Snapshot proposals and forum posts both work this way, so their bodies should start at H2.
 
-You can paste your proposal below to check it against these conventions:
+Paste your proposal below to check it against these conventions:
 
 <ProposalValidator />
 
-### **Phase 1: Temperature Check — Discourse**
+## Phase 1: Temperature Check — Discourse
 
-The purpose of the Temperature Check is to determine if there is sufficient will to make changes to the status quo.
+A Temperature Check gauges whether there is sufficient will to change the status quo.
 
-To create a Temperature Check, ask a general, non-biased question to the community on [discuss.ens.domains](https://discuss.ens.domains) about a potential change (example: "Should ENS decrease registration costs for 3-letter domains?"). Forum posts should be in the "DAO-wide -> Temperature Check" category and titled with the `[Temp Check]` prefix described above.
+Ask a general, non-biased question on [discuss.ens.domains](https://discuss.ens.domains) about a potential change (e.g. "Should ENS decrease registration costs for 3-letter domains?"). Post in the "DAO-wide -> Temperature Check" category with the `[Temp Check]` title prefix described above.
 
-Temperature checks are informal and optional; it's up to you to use the feedback to decide if you want to proceed further with your proposal.
+Temperature checks are informal and optional — use the feedback to decide whether to proceed.
 
-### **Phase 2: Draft Proposal — Discourse**
+## Phase 2: Draft Proposal — Discourse
 
-The purpose of the Draft Proposal is to establish formal discussion around a potential proposal.
+A Draft Proposal establishes formal discussion around a concrete proposal.
 
-To create a Draft Proposal, start by copying the template for an [executable proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md), [social proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md), or [constitutional amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md), as appropriate. Once you have written your proposal, post it in the "DAO-wide -> Draft Proposals" category on [discuss.ens.domains](https://discuss.ens.domains). While the proposal remains a draft, keep the `[Temp Check]` prefix on the forum post title.
+Copy the template for an [executable proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md), [social proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md), or [constitutional amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md), write your proposal, and post it in the "DAO-wide -> Draft Proposals" category on [discuss.ens.domains](https://discuss.ens.domains). Keep the `[Temp Check]` prefix on the title while it remains a draft.
 
-Reach out to your network to build support for the proposal. Discuss the proposal and solicit delegates to provide feedback on it. Be willing to respond to questions on the Draft Proposal topic. Share your viewpoint, although try to remain as impartial as possible.
+Build support: reach out to your network, solicit feedback from delegates, and respond to questions on the topic — while staying as impartial as you can.
 
-If your proposal is an executable proposal, you will need to specify the actions your proposal will take while it is in draft stage. You may wish to wait until the proposal is stable before doing this. The executable proposal template explains how to do this.
+Executable proposals must specify the onchain actions they will take before going to a vote; the template explains how. You may want to wait until the proposal is stable to do this.
 
-If your proposal is a constitutional amendment, you will need to produce a [diff](https://en.wikipedia.org/wiki/Diff) showing the exact changes you are proposing to make to the [constitution](/dao/constitution), and include it in your proposal.
+Constitutional amendments must include a [diff](https://en.wikipedia.org/wiki/Diff) showing the exact changes to the [constitution](/dao/constitution).
 
-Once you are confident the proposal is in a stable state, you can proceed to phase 3.
+Once the proposal is stable, proceed to phase 3.
 
-### **Phase 3: Active Proposal — Snapshot / Governance Portal**
+## Phase 3: Active Proposal — Snapshot / Governance Portal
 
-Once discussion has settled, the proposal can be posted for a vote. Remember to title the vote with the plain proposal title — no `[Temp Check]` prefix, no EP number, and no type tag. The canonical EP number is assigned automatically once the vote is posted, as described in [Titles and Proposal Numbers](#titles-and-proposal-numbers).
+Once discussion has settled, the proposal is posted for a vote. Title the vote with the plain proposal title — no `[Temp Check]` prefix, no EP number, no type tag. The canonical EP number is assigned automatically at this point, as described in [Titles and Proposal Numbers](#titles-and-proposal-numbers).
 
-If your proposal is a Social Proposal or a Constitutional Amendment, it is posted to [Snapshot](https://vote.ensdao.org) for an offchain vote. That's it! If the snapshot vote passes, the proposal is passed and you are done.
+Social Proposals and Constitutional Amendments are posted to [Snapshot](https://vote.ensdao.org) for an offchain vote. That's it — if the vote passes, you're done.
 
-If your proposal is an Executable Proposal, you will now need to submit it to the governor contract for voting onchain.
+Executable Proposals are instead submitted to the governor contract for an onchain vote:
 
-To enact an Executable Proposal:
+1. Ensure at least 100k ENS is delegated to your address, or find a delegate who meets the proposal threshold to propose on your behalf.
+2. Call the `propose()` function on the ENS governor at [governor.ensdao.eth](https://etherscan.io/address/0x323a76393544d5ecca80cd6ef2a560c6a395b7e3).
 
-1. Ensure at least 100k ENS is delegated to your address in order to submit a proposal, or find a delegate who has enough delegated ENS to meet the proposal threshold to propose on your behalf.
-2. Call the propose() function of the ENS governor (at [governor.ensdao.eth](https://etherscan.io/address/0x323a76393544d5ecca80cd6ef2a560c6a395b7e3)) to deploy your proposal.
-
-Once the propose() function has been called, a seven day voting period is started. Ongoing discussion can take place on your proposal post. If the proposal passes successfully, a two day timelock will follow before the proposed code is executed.
+This starts a seven-day voting period, during which discussion can continue on the forum topic. If the proposal passes, a two-day timelock follows before the proposed code is executed.

--- a/src/pages/dao/proposals/submit.mdx
+++ b/src/pages/dao/proposals/submit.mdx
@@ -55,6 +55,11 @@ Proposals are written in markdown, and heading structure matters: multiple H1s r
 
 When a platform provides a separate title field, that field is the H1. Snapshot proposals and forum posts both work this way, so their bodies should start at H2.
 
+Two more common mistakes to avoid:
+
+- Don't skip heading levels (e.g. an H4 directly under an H2) — go one level deeper at a time.
+- Don't use bold text as a heading. If a line introduces a section, make it a real heading; bold is for emphasis within text.
+
 Paste your proposal below to check it against these conventions:
 
 <ProposalValidator />

--- a/src/pages/dao/proposals/submit.mdx
+++ b/src/pages/dao/proposals/submit.mdx
@@ -1,3 +1,5 @@
+import { ProposalValidator } from '../../../components/ProposalValidator'
+
 # Process of Submitting a Proposal
 
 ## Passing a Proposal
@@ -10,37 +12,82 @@ There are three main types of governance proposals you can make:
 2. **[Social Proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md)**: This is a proposal that asks for the agreement of the DAO on something that cannot be enforced onchain. Examples of this include a proposal to change the royalty percentage for the ENS secondary market on OpenSea, or a petition to the root keyholders. Social proposals have a quorum requirement of 1% and require a minimum approval of 50% to pass.
 3. **[Constitutional Amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md)**: This is a social proposal that asks the DAO to amend the constitution. Your draft proposal should include a [diff](https://en.wikipedia.org/wiki/Diff) showing the exact changes you propose to make to the constitution. Rules for amending the constitution are set in the constitution itself, and currently require a quorum of 1% and a minimum approval of two thirds to pass.
 
+### Titles and Proposal Numbers
+
+A proposal's title should contain **only the title of the proposal** — no proposal number and no type tag like `[Executable]` or `[Social]`.
+
+Since the DAO's second working group term, most proposals have self-assigned an EP ("ENS Proposal") number in their title, along with a type tag (e.g. "[7.1] [Social] SPP3: Marketplace RFP"). Because titles are free text, this convention can't be enforced and has broken down in practice: duplicate numbers have been used by unrelated proposals, some funding proposals have been split into sub-numbers like 6.6.1 and 6.6.2 while others haven't, and spacing between the number and the type tag varies from proposal to proposal.
+
+Neither piece of metadata needs to be in the title, because both can be derived objectively:
+
+- **The EP number** is assigned deterministically based on when the proposal is posted for a vote (see below).
+- **The proposal type** is inferred from where the vote takes place: proposals submitted to the [governor contract](https://etherscan.io/address/0x323a76393544d5ecca80cd6ef2a560c6a395b7e3) are Executable Proposals, and proposals posted to Snapshot are Social Proposals.
+
+The only decoration a title should ever carry is a temp check prefix while the proposal is still being discussed on the forum:
+
+- When first sharing a draft proposal on the forum, prepend `[Temp Check]` followed by a space to the title, e.g. "[Temp Check] Do Something Cool".
+- When posting the proposal to Snapshot or the governor contract, use the plain title with no prefix, e.g. "Do Something Cool". At this point, ideally edit the forum topic to remove the `[Temp Check]` prefix there too.
+
+#### How EP numbers are assigned
+
+Offchain systems such as this documentation site assign each proposal a canonical number of the form `{termNumber}.{proposalNumber}`, where `termNumber` is the working group term in which the vote is posted and `proposalNumber` increments sequentially in the order proposals are posted for a vote within that term. Each system may then display the number and inferred type however it sees fit — these docs reconstruct titles in the format "[EP 7.1] [Executable] Do Something Cool".
+
+This system takes effect as of July 14, 2026. Proposals posted before that date keep their existing EP numbers and will not be renumbered — the [proposals directory in the docs repository](https://github.com/ensdomains/docs/tree/master/src/pages/dao/proposals) serves as the canonical list of EP numbers assigned to date.
+
+A few clarifications on how numbering works:
+
+- A proposal only receives its number once it is posted for a vote. Drafts and temp checks are not numbered.
+- Numbers are never reused. A proposal that is defeated or cancelled keeps its number, and a resubmission is a new proposal that receives the next number.
+- A Snapshot vote and an onchain vote are always separate proposals with separate numbers, even if they concern the same matter (e.g. a social vote followed by an executable vote implementing its outcome).
+- Related proposals voted on separately (e.g. a funding request split into multiple votes) are simply separate proposals, each receiving the next sequential number. Do not construct sub-numbers like 6.6.1 — that scheme appears in older proposals for historical reasons only.
+
+### Formatting
+
+Proposals are written in markdown, and semantic heading structure matters: many past proposals use multiple H1s, which renders weirdly on governance apps, hurts SEO, and hurts accessibility. A document should have at most one H1 — the proposal title — followed by H2 headings for each section:
+
+```md
+# Title
+
+## Abstract
+
+## Motivation
+
+## Specification
+```
+
+When the platform provides a separate title field, that field is the H1. Snapshot proposals and forum posts both work this way, so their bodies should contain no H1 at all — the largest heading should be an H2.
+
+You can paste your proposal below to check it against these conventions:
+
+<ProposalValidator />
+
 ### **Phase 1: Temperature Check — Discourse**
 
 The purpose of the Temperature Check is to determine if there is sufficient will to make changes to the status quo.
 
-To create a Temperature Check, ask a general, non-biased question to the community on [discuss.ens.domains](https://discuss.ens.domains) about a potential change (example: "Should ENS decrease registration costs for 3-letter domains?"). Forum posts should be in the "DAO-wide -> Temperature Check" category.
+To create a Temperature Check, ask a general, non-biased question to the community on [discuss.ens.domains](https://discuss.ens.domains) about a potential change (example: "Should ENS decrease registration costs for 3-letter domains?"). Forum posts should be in the "DAO-wide -> Temperature Check" category and titled with the `[Temp Check]` prefix described above.
 
 Temperature checks are informal and optional; it's up to you to use the feedback to decide if you want to proceed further with your proposal.
 
-### **Phase 2: Draft Proposal — GitHub**
+### **Phase 2: Draft Proposal — Discourse**
 
 The purpose of the Draft Proposal is to establish formal discussion around a potential proposal.
 
-To create a Draft Proposal, [create a new governance proposal](https://github.com/ensdomains/governance-docs/new/main/governance-proposals) in the governance-docs repository on GitHub. Start by copying the template for an [executable proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md), [social proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md), or [constitutional amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md), as appropriate. Once you have written your proposal, create a Draft Pull Request for it. Start a new post in the DAO-wide -> Draft Proposals" category with a link to the PR for discussion.
+To create a Draft Proposal, start by copying the template for an [executable proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/executable-proposal-template.md), [social proposal](https://github.com/ensdomains/docs/tree/master/src/public/governance/social-proposal-template.md), or [constitutional amendment](https://github.com/ensdomains/docs/tree/master/src/public/governance/constitutional-amendment-template.md), as appropriate. Once you have written your proposal, post it in the "DAO-wide -> Draft Proposals" category on [discuss.ens.domains](https://discuss.ens.domains). While the proposal remains a draft, keep the `[Temp Check]` prefix on the forum post title.
 
-Reach out to your network to build support for the proposal. Discuss the proposal and solicit delegates to provide feedback on it. Be willing to respond to questions on the Draft Proposal topic and in comments on the pull request. Share your viewpoint, although try to remain as impartial as possible.
+Reach out to your network to build support for the proposal. Discuss the proposal and solicit delegates to provide feedback on it. Be willing to respond to questions on the Draft Proposal topic. Share your viewpoint, although try to remain as impartial as possible.
 
 If your proposal is an executable proposal, you will need to specify the actions your proposal will take while it is in draft stage. You may wish to wait until the proposal is stable before doing this. The executable proposal template explains how to do this.
 
-If your proposal is a constitutional amendment, you will need to produce a diff showing the exact changes you are proposing to make. The easiest way to do this is to go to the [constitution](/dao/constitution), click "Edit on GitHub", then click the pencil icon to edit the document in a fork. You can then create a pull request via the GitHub UI and include this in your proposal. You should do this in a separate branch to your draft proposal; while the proposal will be merged as soon as it goes to a vote, the amendment will only be merged if the proposal passes.
+If your proposal is a constitutional amendment, you will need to produce a [diff](https://en.wikipedia.org/wiki/Diff) showing the exact changes you are proposing to make to the [constitution](/dao/constitution), and include it in your proposal.
 
 Once you are confident the proposal is in a stable state, you can proceed to phase 3.
 
 ### **Phase 3: Active Proposal — Snapshot / Governance Portal**
 
-Use GitHub to flag your PR as Ready for Review. A contributor will:
+Once discussion has settled, the proposal can be posted for a vote. Remember to title the vote with the plain proposal title — no `[Temp Check]` prefix, no EP number, and no type tag. The canonical EP number is assigned automatically once the vote is posted, as described in [Titles and Proposal Numbers](#titles-and-proposal-numbers).
 
-1. Merge your PR if it meets the requirements.
-2. Assign your proposal a proposal number in the form EP###.
-3. Schedule the proposal for a snapshot vote.
-
-If your proposal is a Social Proposal or a Constitutional Amendment, that's it! If the snapshot vote passes, the proposal is passed and you are done.
+If your proposal is a Social Proposal or a Constitutional Amendment, it is posted to [Snapshot](https://vote.ensdao.org) for an offchain vote. That's it! If the snapshot vote passes, the proposal is passed and you are done.
 
 If your proposal is an Executable Proposal, you will now need to submit it to the governor contract for voting onchain.
 

--- a/src/pages/dao/proposals/submit.mdx
+++ b/src/pages/dao/proposals/submit.mdx
@@ -30,7 +30,7 @@ The one exception is a temp check prefix while the proposal is still a draft on 
 
 Offchain platforms such as this site assign each proposal a canonical number of the form `{termNumber}.{proposalNumber}`: the working group term in which the vote is posted, and a counter that increments with each vote posted during that term. Each platform displays the number and inferred type as it sees fit — these docs reconstruct titles like "[EP 7.1] [Executable] Do Something Cool".
 
-This system takes effect July 14, 2026. Earlier proposals keep their EP numbers — the [proposals directory in this repository](https://github.com/ensdomains/docs/tree/master/src/pages/dao/proposals) is the canonical list of numbers assigned to date.
+This system takes effect July 1, 2026, the start of Term 7. Earlier proposals keep their EP numbers — the [proposals directory in this repository](https://github.com/ensdomains/docs/tree/master/src/pages/dao/proposals) is the canonical list of numbers assigned to date.
 
 A few details:
 

--- a/src/pages/dao/proposals/submit.mdx
+++ b/src/pages/dao/proposals/submit.mdx
@@ -35,7 +35,7 @@ This system takes effect July 1, 2026, the start of Term 7. Earlier proposals ke
 A few details:
 
 - A proposal is only numbered once it is posted for a vote. Drafts and temp checks are not.
-- Numbers are never reused. A defeated or cancelled proposal keeps its number, and a resubmission gets the next one.
+- Numbers are never reused. A defeated or cancelled proposal keeps its number, and a resubmission gets the next one. The one exception is a Snapshot proposal that is deleted from the platform and re-created with only minor changes (e.g. typo fixes) within 24 hours — the replacement reuses the original number.
 - A Snapshot vote and an onchain vote are always separate proposals with separate numbers, even when they concern the same matter (e.g. a social vote followed by an executable vote implementing it).
 - Related proposals voted on separately (e.g. a funding request split into multiple votes) are just separate proposals with sequential numbers. Never construct sub-numbers like 6.6.1 — those only exist in older proposals.
 

--- a/src/public/governance/executable-proposal-template.md
+++ b/src/public/governance/executable-proposal-template.md
@@ -26,8 +26,10 @@ description: A short (1-2 sentence) description of the proposal.
 ## Transactions
 
 <!--
-  The transactions section describes all the calls that should be encoded in the onchain version of this proposal. List one block per call, using the format below as a starting point.
+  The transactions section describes all the calls that should be encoded in the onchain version of this proposal. List one block per call, each preceded by a heading describing what it does, using the format below as a starting point.
 -->
+
+### Transfer 100k USDC to Metagov
 
 ```
 Target: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC token)
@@ -36,5 +38,5 @@ Function: transfer(address to, uint256 value)
 
 Arguments:
 - 0x91c32893216dE3eA0a55ABb9851f581d4503d39b (Metagov Safe)
-- 100000000000 (100k tokens)
+- 100000000000 (100k USDC)
 ```

--- a/src/public/governance/executable-proposal-template.md
+++ b/src/public/governance/executable-proposal-template.md
@@ -26,26 +26,15 @@ description: A short (1-2 sentence) description of the proposal.
 ## Transactions
 
 <!--
-  The transactions section describes all the calls that should be encoded in the onchain version of this proposal. Use the table below as a starting point.
+  The transactions section describes all the calls that should be encoded in the onchain version of this proposal. List one block per call, using the format below as a starting point.
 -->
 
-<table>
-    <tr>
-        <th>Address</th>
-        <th>Value</th>
-        <th>Function</th>
-        <th>Argument</th>
-        <th>Value</th>
-    </tr>
-    <tr>
-        <td rowspan=2>Address or ENS name of target</td>
-        <td rowspan=2>Value to send (ETH)</td>
-        <td rowspan=2>Function identifier</td>
-        <td>First arg</td>
-        <td>First value</td>
-    </tr>
-    <tr>
-        <td>Second arg</td>
-        <td>Second value</td>
-    </tr>
-</table>
+```
+Target: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC token)
+
+Function: transfer(address to, uint256 value)
+
+Arguments:
+- 0x91c32893216dE3eA0a55ABb9851f581d4503d39b (Metagov Safe)
+- 100000000000 (100k tokens)
+```

--- a/src/public/governance/executable-proposal-template.md
+++ b/src/public/governance/executable-proposal-template.md
@@ -26,10 +26,10 @@ description: A short (1-2 sentence) description of the proposal.
 ## Transactions
 
 <!--
-  The transactions section describes all the calls that should be encoded in the onchain version of this proposal. List one block per call, each preceded by a heading describing what it does, using the format below as a starting point.
+  The transactions section describes all the calls that should be encoded in the onchain version of this proposal. List one block per call, each preceded by a short line describing what it does, using the format below as a starting point.
 -->
 
-### Transfer 100k USDC to Metagov
+Transfer 100k USDC to Metagov
 
 ```
 Target: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (USDC token)


### PR DESCRIPTION
## What changed

Updates the proposal submission docs to reflect the conventions proposed in [Standardizing DAO proposal formatting](https://discuss.ens.domains/t/standardizing-dao-proposal-formatting/22281):

**`dao/proposals/submit` — new "Titles and Proposal Numbers" section**
- Proposal titles contain only the title itself — no self-assigned EP numbers, no `[Executable]`/`[Social]` tags
- EP numbers are assigned deterministically (`{termNumber}.{proposalNumber}`, sequential per term) by offchain systems once a vote is posted; the type is inferred from the venue (governor contract → Executable, Snapshot → Social)
- Forum drafts carry a `[Temp Check]` title prefix, dropped when the vote is posted (and ideally removed from the forum topic at that point)
- Takes effect July 14, 2026; existing EPs are not renumbered, with the proposals directory in this repo as the canonical historical list
- Edge cases spelled out: drafts are unnumbered, numbers are never reused, Snapshot + onchain votes on the same matter are separate proposals, and no new sub-numbering (6.6.1-style numbers are historical only)

**New "Formatting" section** — one H1 (the title) followed by H2 sections (`Abstract`/`Motivation`/`Specification`); on platforms with a separate title field (Snapshot, the forum) the body starts at H2

**GitHub removed from the process** — the governance-docs repo no longer exists, so Phase 2 is now "Draft Proposal — Discourse" (templates are copied from `src/public/governance/` in this repo) and Phase 3 no longer references PR review or manual `EP###` assignment. The duplicated flow in `dao/governance/process` is updated to match.

**New `ProposalValidator` component** — embedded on the submit page: paste proposal markdown, get live errors (EP number/type tag in title, multiple H1s, H1 not first, no headings) and warnings (`[Temp Check]` prefix, skipped heading levels, missing typical sections). Pastes containing escaped `\n` sequences (common when copying from chat tools) are auto-converted to real newlines. Headings inside code fences are ignored, and zero-H1 documents are accepted for Snapshot-style bodies.

## Notes for reviewers

- Validation logic was tested with 14 cases (escaped-newline beautify, code fences, false-positive checks like "SPP3" in titles) and verified in the browser in dark mode
- `dao/foundation` still links PDFs in the dead governance-docs repo; that's being handled separately
- The sidebar generator (`scripts/dao-proposals.ts`) and proposal frontmatter still use manually-assigned numbers/types — automating derivation from Snapshot/governor data would be a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)