### PR TITLE
Point ENSv2 preview banner at the branch preview

### DIFF
--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -31,7 +31,7 @@ export default defineConfig({
     content: (
       <p>
         Hacking on Sepolia?{' '}
-        <a href="https://pr-543.docs-bao.pages.dev/contracts/ensv2/overview/">
+        <a href="https://feature-ensv2-docs.docs-bao.pages.dev/contracts/ensv2/overview">
           Read the ENSv2 docs preview
         </a>
         .


### PR DESCRIPTION
The pr-543 preview is frozen at that PR's last build; the feature-ensv2-docs alias always serves the latest commit on the branch.