### PR TITLE
Add NameWhisper MCP to Community MCP Servers

### DIFF
--- a/src/pages/building-with-ai.mdx
+++ b/src/pages/building-with-ai.mdx
@@ -100,6 +100,7 @@ The community has built additional MCP servers that may be useful for ENS and gr
 - **[ETHID MCP](https://ethidentitykit.com/docs/ai-tools/ethid-mcp)** - Tools for working with ENS and EFP
 - **[Ethereum MCP](https://github.com/gskril/ethereum-mcp)** - General-purpose EVM tools including ENS resolution, ABI parsing, and more
 - **[ENS MCP by Namespace](https://github.com/thenamespace/ens-mcp)** - Lets AI agents query ENS names, subnames, ownership, profiles, pricing, availability, and history.
+- **[NameWhisper MCP](https://github.com/eggybug42069/namewhisper-mcp)** - Search 3.5M+ indexed ENS names in natural language, get comparable-sales valuations and market data, and build registration, renewal, and marketplace transactions. Also available as a remote server at `https://namewhisper.ai/mcp`.
 
 These are independently maintained by community members. Check their documentation for installation instructions and available features.
 


### PR DESCRIPTION
Adds [NameWhisper MCP](https://github.com/eggybug42069/namewhisper-mcp) to the Community MCP Servers list, following the format of the existing entries.

NameWhisper is an ENS-focused MCP server (AGPL-3.0, open source) exposing 44 tools: natural-language search across 3.5M+ indexed ENS names, comparable-sales valuations, market data (sales/listings/offers), portfolio lookups, and transaction building for registration, renewal, records, and marketplace actions. It runs as an npx stdio package or as a remote streamable-http server at `https://namewhisper.ai/mcp` (listed on the MCP Registry as `ai.namewhisper/ens-tools`).

One-line MDX change, matching the existing entry format.