### PR TITLE
Update go-ens ENSv2 readiness to ENS-maintained v4

### DIFF
--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -9,7 +9,7 @@ The good news? For most applications, preparing for ENSv2 is as simple as updati
 - **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01).
 - **ENSjs:** [>= v4.2.3](https://github.com/ensdomains/ensjs/releases/tag/%40ensdomains%2Fensjs%404.2.3).
 - **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true).
-- **go-ens:** Native support not published yet. [Work in progress in PR #49](https://github.com/wealdtech/go-ens/pull/49).
+- **go-ens:** [>= v4](https://github.com/ensdomains/go-ens).
 - **web3.js:** Deprecated.
 
 :::info

--- a/src/pages/web/ensv2-readiness.mdx
+++ b/src/pages/web/ensv2-readiness.mdx
@@ -9,7 +9,7 @@ The good news? For most applications, preparing for ENSv2 is as simple as updati
 - **web3.py:** [>= v7.16.0](https://web3py.readthedocs.io/en/stable/release_notes.html#web3-py-v7-16-0-2026-05-01).
 - **ENSjs:** [>= v4.2.3](https://github.com/ensdomains/ensjs/releases/tag/%40ensdomains%2Fensjs%404.2.3).
 - **web3j:** [>= v5.0.3](https://central.sonatype.com/artifact/org.web3j/core?smo=true).
-- **go-ens:** [>= v4](https://github.com/ensdomains/go-ens).
+- **go-ens:** [>= v4.0.0](https://github.com/ensdomains/go-ens).
 - **web3.js:** Deprecated.
 
 :::info


### PR DESCRIPTION
## Summary
- Replace the outdated wealdtech go-ens WIP note on the ENSv2 readiness page with a link to the ENS-maintained v4 library: https://github.com/ensdomains/go-ens
- Match the other library entries (`>= vX`) now that native ENSv2 support is published