### PR TITLE
Update support links

### DIFF
--- a/src/pages/registry/eth.mdx
+++ b/src/pages/registry/eth.mdx
@@ -57,7 +57,7 @@ This is done to prevent sniping of names, and ensures the name goes to the highe
   </div>
 </Card>
 
-You can read more about the temporary premium in [this article](https://support.ens.domains/en/articles/7900612-temporary-premium).
+You can read more about the temporary premium in [this article](https://support.ens.domains/en/articles/7900612-what-is-temporary-premium).
 
 ### Where does the money go?
 

--- a/src/pages/resolution/names.mdx
+++ b/src/pages/resolution/names.mdx
@@ -19,7 +19,7 @@ For example, `NaMe.EtH` normalizes to `name.eth`. This ensures that the correct 
 
 ENS names are validated and normalized using the [ENSIP-15](/ensip/15) normalization algorithm.
 
-Previously, [UTS-46](https://www.unicode.org/reports/tr46/) was used, but that is insufficient for emoji sequences. Correct emoji processing is only possible with [UTS-51](https://www.unicode.org/reports/tr51/). The [ENSIP-15](/ensip/15) normalization algorithm draws from those older Unicode standards, but also adds many other validation rules to prevent common spoofing techniques like inserting zero-width characters, or using confusable (look-alike) characters. See here for additional discussion on this: [Homogylphs](https://support.ens.domains/en/articles/7901658-homoglyphs)
+Previously, [UTS-46](https://www.unicode.org/reports/tr46/) was used, but that is insufficient for emoji sequences. Correct emoji processing is only possible with [UTS-51](https://www.unicode.org/reports/tr51/). The [ENSIP-15](/ensip/15) normalization algorithm draws from those older Unicode standards, but also adds many other validation rules to prevent common spoofing techniques like inserting zero-width characters, or using confusable (look-alike) characters. See here for additional discussion on this: [Homogylphs](https://support.ens.domains/en/articles/7901658-what-are-homoglyphs-and-lookalike-ens-names)
 
 A standard implementation of the algorithm is available at [@adraffy/ens-normalize](https://github.com/adraffy/ens-normalize.js). This library is used under the hood in [viem](https://viem.sh/docs/ens/utilities/normalize), [ENSjs](https://github.com/ensdomains/ensjs/blob/main/packages/ensjs/src/utils/normalise.ts#L27), and others.
 

--- a/src/pages/wrapper/overview.mdx
+++ b/src/pages/wrapper/overview.mdx
@@ -3,7 +3,7 @@ import { Card } from '../../components/ui/Card'
 # Name Wrapper Overview
 
 :::note
-Are you looking for user-facing guides on how to interact with the Name Wrapper in the ENS Manager App? If so, see here instead: [Name Wrapper Guides](https://support.ens.domains/en/collections/4194784-name-wrapper-guides)
+Are you looking for user-facing guides on how to interact with the Name Wrapper in the ENS Manager App? If so, see here instead: [Name Wrapper Guides](https://support.ens.domains/en/collections/17928216-advanced-name-wrapper)
 :::
 
 <iframe

--- a/src/pages/wrapper/usecases.mdx
+++ b/src/pages/wrapper/usecases.mdx
@@ -98,7 +98,7 @@ And so on, it's up to you. You can also burn whatever custom parent-controlled o
 
 Yes! It's your registrar contract, so you can impose whatever rules and fees you want.
 
-For example, the .eth Registrar imposes a 3-character minimum on all names, as well as a [custom fee structure](https://support.ens.domains/core/registration/fees) and a [temporary premium auction](https://support.ens.domains/core/registration/temporary-premium) upon expiration.
+For example, the .eth Registrar imposes a 3-character minimum on all names, as well as a [custom fee structure](https://support.ens.domains/en/articles/12238910-pricing-fees) and a [temporary premium auction](https://support.ens.domains/en/articles/7900612-what-is-temporary-premium) upon expiration.
 
 By default there is no character limit on subnames, but your contract could have its own rules and fee structure or whatever you want. For example, you can:
 


### PR DESCRIPTION
Five support.ens.domains links point at retired or renamed articles.

- Name Wrapper guides collection → Advanced: Name Wrapper
- /core/registration/fees → Pricing & Fees
- /core/registration/temporary-premium → What is temporary premium?
- Temporary premium and homoglyphs articles → current slugs

The first two served retired pages rather than 404ing, so they read as healthy.