### PR TITLE
Remove references to deprecated tools

### DIFF
--- a/src/pages/web/naming-contracts.mdx
+++ b/src/pages/web/naming-contracts.mdx
@@ -8,8 +8,6 @@ In order for you to manage the primary name of your smart contract, you need to 
 To enable reverse resolution, you must set both the reverse record and the ETH address to the contract’s deployed address.
 :::
 
-Skip to [Naming Tools](#naming-tools) for a frontend solution to naming your smart contracts.
-
 ## New Contracts
 
 Depending on your use case, there are a few ways to set a smart contract's primary name.
@@ -122,22 +120,3 @@ If your contract supports the [Ownable](https://docs.openzeppelin.com/contracts/
 If your contract is a Safe, Multisig, DAO or otherwise has the ability to execute arbitrary calldata, you can use a [Reverse Registrar](/registry/reverse) contract directly to set a name for it.
 
 You might even be able to use the [ENS Manager App](https://app.ens.domains/) inside of your safe app to set a primary name.
-
-## Naming Tools
-
-:::warning
-These are 3rd party tools and not officially supported by ENS Labs.
-:::
-
-[Enscribe](https://app.enscribe.xyz/) is a tool designed to simplify the process of naming smart contracts with ENS names. The application enables users to deploy new smart contracts with a primary name directly and easily name existing smart contracts.
-
-Enscribe simplifies what is otherwise a multi-step, error-prone process by offering:
-
-- Atomic contract deployment using `CREATE2`
-- Naming `Ownable`, `ERC173` and `ReverseClaimer` contracts as described above
-- ENS subname creation, forward resolution and reverse record assignment
-- Naming of existing contracts, with an easy way to locate contracts that you've already deployed
-
-Even if you don't own an ENS name, you can still utilize Enscribe's hosted ENS parent, `deployd.eth`, to create subnames like `my-app.deployd.eth` and set them as the primary name for your contract.
-
-To learn more, refer to the [Enscribe Docs](https://www.enscribe.xyz/docs/).

--- a/src/pages/web/subdomains.mdx
+++ b/src/pages/web/subdomains.mdx
@@ -66,4 +66,4 @@ Offchain subnames are exactly what they sound like - subnames that live in a cen
 
 From a user perspective, offchain subnames are hardly different than onchain subnames. They will not appear in wallet applications as NFTs like the previous two approaches, but they can resolve all the same data (addresses, text records, etc).
 
-There are multiple API providers that offer programmatic access to offchain subnames such as [NameStone](https://namestone.com/), [Namespace](https://namespace.ninja/) and [JustaName](https://justaname.id/), along with open-source examples like [gskril/ens-offchain-registrar](https://github.com/gskril/ens-offchain-registrar).
+There are API providers that offer programmatic access to offchain subnames such as [Namespace](https://namespace.ninja/), along with open-source examples like [gskril/ens-offchain-registrar](https://github.com/gskril/ens-offchain-registrar).


### PR DESCRIPTION
NameStone, JustaName and Enscribe have all been deprecated, so this removes them from the docs.

### Changes

- **`src/pages/web/naming-contracts.mdx`** — removed the "Naming Tools" section (which covered Enscribe exclusively) along with the "Skip to Naming Tools" pointer near the top of the page that linked to it. Nothing else linked to that anchor.
- **`src/pages/web/subdomains.mdx`** — dropped NameStone and JustaName from the list of offchain subname API providers, leaving Namespace and the `gskril/ens-offchain-registrar` open-source example.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ndheeZi7bcQqknH2QcJSF)_